### PR TITLE
Update type hinting and remove redundant imports from `typing`

### DIFF
--- a/docs/dev/extend.rst
+++ b/docs/dev/extend.rst
@@ -112,14 +112,13 @@ less boilerplate and free validation on instantiation:
 .. code-block:: python
 
     from datetime import datetime
-    from typing import List, Optional
     from pydantic import BaseModel
 
     class User(BaseModel):
         id: int
         name = 'John Doe'
-        signup_ts: Optional[datetime] = None
-        friends: List[int] = []
+        signup_ts: datetime | None = None
+        friends: list[int] = []
 
 Note how in the above example we need no `__init__` method like a dataclass. We can define
 types and defaults for fields. We can even constrain fields (specifying a range of valid options

--- a/docs/dev/geometry.rst
+++ b/docs/dev/geometry.rst
@@ -18,7 +18,7 @@ using this geometry, namely D-Settlement and D-Stability.
 
 In our API we use the D-Settlement approach::
     - add_point(Point) -> point_id:int
-    - add_layer(List[point_id]) -> layer_id:int
+    - add_layer(list[point_id]) -> layer_id:int
 
 Where we use references to previously added points to ensure
 topological consistency. This is why we have not introduced a LineString

--- a/geolib/geometry/one.py
+++ b/geolib/geometry/one.py
@@ -10,7 +10,6 @@ For profiles used in 1D applications, see :class:`~geolib.soils.layers.ProfileLa
 """
 
 from math import isclose
-from typing import Optional
 
 from geolib.models import BaseDataClass
 
@@ -20,8 +19,8 @@ NODATA = -999.0  # TODO why is this implemented instead of None?
 class Point(BaseDataClass):
     """A single Point Class."""
 
-    label: Optional[str] = ""
-    id: Optional[int] = None
+    label: str | None = ""
+    id: int | None = None
     x: float = NODATA
     y: float = NODATA
     z: float = NODATA

--- a/geolib/models/base_model.py
+++ b/geolib/models/base_model.py
@@ -8,7 +8,6 @@ import logging
 from abc import abstractmethod
 from pathlib import Path
 from subprocess import run
-from typing import List, Optional, Type, Union
 
 import requests
 from pydantic import DirectoryPath, FilePath, HttpUrl, SerializeAsAny, ValidationError
@@ -25,8 +24,8 @@ meta = MetaData()
 
 
 class BaseModel(BaseDataClass, abc.ABC):
-    filename: Optional[Path] = None
-    datastructure: Optional[SerializeAsAny[BaseModelStructure]] = None
+    filename: Path | None = None
+    datastructure: SerializeAsAny[BaseModelStructure] | None = None
     """
     This is the base class for all models in GEOLib.
     
@@ -130,8 +129,8 @@ class BaseModel(BaseDataClass, abc.ABC):
 
     @abstractmethod
     def serialize(
-        self, filename: Union[FilePath, DirectoryPath, None]
-    ) -> Union[FilePath, DirectoryPath, None]:
+        self, filename: FilePath | DirectoryPath | None
+    ) -> FilePath | DirectoryPath | None:
         """Serialize model to input file."""
 
     @property
@@ -139,27 +138,27 @@ class BaseModel(BaseDataClass, abc.ABC):
         raise NotImplementedError("Implement in concrete classes.")
 
     @property
-    def custom_console_path(self) -> Optional[Path]:
+    def custom_console_path(self) -> Path | None:
         return None
 
     @property
-    def console_flags(self) -> List[str]:
+    def console_flags(self) -> list[str]:
         return []
 
     @property
-    def console_flags_post(self) -> List[str]:
+    def console_flags_post(self) -> list[str]:
         return []
 
     @property
     @abstractmethod
-    def parser_provider_type(self) -> Type[BaseParserProvider]:
+    def parser_provider_type(self) -> type[BaseParserProvider]:
         """Returns the parser provider type of the current concrete class.
 
         Raises:
             NotImplementedError: If not implemented in the concrete class.
 
         Returns:
-            Type[BaseParserProvider] -- Concrete parser provider.
+            type[BaseParserProvider] -- Concrete parser provider.
         """
         raise NotImplementedError("Implement in concrete classes.")
 
@@ -192,7 +191,7 @@ class BaseModel(BaseDataClass, abc.ABC):
         """
         return self.datastructure.results
 
-    def get_meta_property(self, key: str) -> Optional[str]:
+    def get_meta_property(self, key: str) -> str | None:
         """Get a metadata property from the input file."""
         if hasattr(meta, key):
             return meta.__getattribute__(key)

--- a/geolib/models/base_model_list.py
+++ b/geolib/models/base_model_list.py
@@ -1,7 +1,6 @@
 import logging
 import os
 from subprocess import Popen
-from typing import List, Optional
 
 import requests
 from pydantic import DirectoryPath, HttpUrl
@@ -23,14 +22,14 @@ class BaseModelList(BaseDataClass):
     otherwise they will overwrite eachother. This also helps with
     identifying them later."""
 
-    models: List[BaseModel]
-    errors: List[str] = []
+    models: list[BaseModel]
+    errors: list[str] = []
 
     def execute(
         self,
         calculation_folder: DirectoryPath,
         timeout_in_seconds: int = meta.timeout,
-        nprocesses: Optional[int] = os.cpu_count(),
+        nprocesses: int | None = os.cpu_count(),
     ) -> "BaseModelList":
         """Execute all models in this class in parallel.
 

--- a/geolib/models/dfoundations/dfoundations_model.py
+++ b/geolib/models/dfoundations/dfoundations_model.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import BinaryIO, List, Optional, Type, Union
+from typing import BinaryIO
 
 from pydantic import Field, FilePath
 from typing_extensions import Annotated
@@ -50,9 +50,9 @@ class ModelOptions(BaseDataClass):
     max_allowed_settlement_lim_state_serv: Annotated[float, Field(ge=0, le=100000)] = 0
     max_allowed_rel_rotation_lim_state_serv: Annotated[int, Field(ge=1, le=10000)] = 300
     # Factors
-    factor_xi3: Optional[Annotated[float, Field(ge=0.01, le=10)]] = None
-    factor_xi4: Optional[Annotated[float, Field(ge=0.01, le=10)]] = None
-    ea_gem: Optional[Annotated[float, Field(ge=1)]] = None
+    factor_xi3: Annotated[float, Field(ge=0.01, le=10)] | None = None
+    factor_xi4: Annotated[float, Field(ge=0.01, le=10)] | None = None
+    ea_gem: Annotated[float, Field(ge=1)] | None = None
 
     # Combined Model Options
     is_suppress_qc_reduction: Bool = False
@@ -72,10 +72,10 @@ class ModelOptions(BaseDataClass):
 
 
 class BearingPilesModel(ModelOptions):
-    factor_gamma_b: Optional[Annotated[float, Field(ge=1, le=100)]] = None
-    factor_gamma_s: Optional[Annotated[float, Field(ge=1, le=100)]] = None
-    factor_gamma_fnk: Optional[Annotated[float, Field(ge=-100, le=100)]] = None
-    area: Optional[Annotated[float, Field(ge=0, le=100000)]] = None
+    factor_gamma_b: Annotated[float, Field(ge=1, le=100)] | None = None
+    factor_gamma_s: Annotated[float, Field(ge=1, le=100)] | None = None
+    factor_gamma_fnk: Annotated[float, Field(ge=-100, le=100)] | None = None
+    area: Annotated[float, Field(ge=0, le=100000)] | None = None
 
     @classmethod
     def model_type(cls):
@@ -88,9 +88,9 @@ class TensionPilesModel(ModelOptions):
     surcharge: Annotated[float, Field(ge=0, le=1e7)] = 0
     use_piezometric_levels: Bool = True
 
-    factor_gamma_var: Optional[Annotated[float, Field(ge=0.01, le=100)]] = None
-    factor_gamma_st: Optional[Annotated[float, Field(ge=0.01, le=100)]] = None
-    factor_gamma_gamma: Optional[Annotated[float, Field(ge=0.01, le=100)]] = None
+    factor_gamma_var: Annotated[float, Field(ge=0.01, le=100)] | None = None
+    factor_gamma_st: Annotated[float, Field(ge=0.01, le=100)] | None = None
+    factor_gamma_gamma: Annotated[float, Field(ge=0.01, le=100)] | None = None
 
     @classmethod
     def model_type(cls):
@@ -117,8 +117,8 @@ class CalculationOptions(BaseDataClass):
 
     calculationtype: CalculationType
 
-    net_bearing_capacity: Optional[float] = 0  # [kN]
-    cpt_test_level: Optional[float] = 0.0  # [m]
+    net_bearing_capacity: float | None = 0  # [kN]
+    cpt_test_level: float | None = 0.0  # [m]
 
     trajectory_begin: float = -10.00
     trajectory_end: float = -25.00
@@ -136,13 +136,10 @@ class DFoundationsModel(BaseModel):
     This model can read, modify and create \*.foi files, read \*.fod and \*.err files.
     """
 
-    datastructure: Union[
-        DFoundationsDumpStructure,
-        DFoundationsStructure,
-    ] = DFoundationsStructure()
+    datastructure: DFoundationsDumpStructure | DFoundationsStructure = DFoundationsStructure()
 
     @property
-    def parser_provider_type(self) -> Type[DFoundationsParserProvider]:
+    def parser_provider_type(self) -> type[DFoundationsParserProvider]:
         return DFoundationsParserProvider
 
     @property
@@ -154,7 +151,7 @@ class DFoundationsModel(BaseModel):
         return self.get_meta_property("dfoundations_console_path")
 
     @property
-    def console_flags(self) -> List[str]:
+    def console_flags(self) -> list[str]:
         return [CONSOLE_RUN_BATCH_FLAG]
 
     @property
@@ -165,7 +162,7 @@ class DFoundationsModel(BaseModel):
     def input(self):
         return self.datastructure.input_data
 
-    def serialize(self, filename: Union[FilePath, BinaryIO]):
+    def serialize(self, filename: FilePath | BinaryIO):
         serializer = DFoundationsInputSerializer(ds=self.datastructure.model_dump())
         serializer.write(filename)
 
@@ -174,7 +171,7 @@ class DFoundationsModel(BaseModel):
 
     def set_model(
         self,
-        model: Union[BearingPilesModel, TensionPilesModel],
+        model: BearingPilesModel | TensionPilesModel,
         calculation: CalculationOptions,
     ) -> None:
         """(Re)Set ModelType (Bearing/Tension) and ConstructionType for model.

--- a/geolib/models/dfoundations/dfoundations_parserprovider.py
+++ b/geolib/models/dfoundations/dfoundations_parserprovider.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Type
-
 from pydantic import FilePath
 
 from geolib.models.dseries_parser import DSerieParser, DSeriesStructure
@@ -17,11 +15,11 @@ class DFoundationsInputParser(DSerieParser):
     """DFoundations parser of input files."""
 
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".foi"]
 
     @property
-    def dserie_structure(self) -> Type[DFoundationsStructure]:
+    def dserie_structure(self) -> type[DFoundationsStructure]:
         return DFoundationsStructure
 
 
@@ -29,11 +27,11 @@ class DFoundationsOutputParser(DSerieParser):
     """DFoundations parser of input files."""
 
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".fod"]
 
     @property
-    def dserie_structure(self) -> Type[DFoundationsDumpStructure]:
+    def dserie_structure(self) -> type[DFoundationsDumpStructure]:
         return DFoundationsDumpStructure
 
 
@@ -42,13 +40,13 @@ class DFoundationsParserProvider(BaseParserProvider):
     __output_parsers = None
 
     @property
-    def input_parsers(self) -> Tuple[DFoundationsInputParser]:
+    def input_parsers(self) -> tuple[DFoundationsInputParser]:
         if not self.__input_parsers:
             self.__input_parsers = (DFoundationsInputParser(),)
         return self.__input_parsers
 
     @property
-    def output_parsers(self) -> Tuple[DFoundationsOutputParser]:
+    def output_parsers(self) -> tuple[DFoundationsOutputParser]:
         if not self.__output_parsers:
             self.__output_parsers = (DFoundationsOutputParser(),)
         return self.__output_parsers

--- a/geolib/models/dfoundations/dfoundations_structures.py
+++ b/geolib/models/dfoundations/dfoundations_structures.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 from geolib.models.dseries_parser import (
     DSerieListGroupNextStructure,
@@ -21,7 +21,7 @@ class DFoundationsEnumStructure(DSeriesStructure):
         return cls(**kwargs)
 
     @staticmethod
-    def remove_enum_explanation(structure: Dict[str, Any]) -> Dict[str, Any]:
+    def remove_enum_explanation(structure: dict[str, Any]) -> dict[str, Any]:
         """Remove trailing explanations from values of `structure`
         0 : Mechanical qc required -> 0
         """
@@ -35,7 +35,7 @@ class DFoundationsEnumStructure(DSeriesStructure):
 
 class DFoundationsInlineProperties(DSeriesInlineProperties):
     @classmethod
-    def get_property_key_value(cls, text: str, expected_property: str) -> Tuple[str, str]:
+    def get_property_key_value(cls, text: str, expected_property: str) -> tuple[str, str]:
         """Returns the value content for a line of format:
         value : key || value = key
 
@@ -76,7 +76,7 @@ class DFoundationsTableWrapper(DSeriesStructure):
             DSerieStructure: Parsed structure.
         """
 
-        def split_line(text: str) -> List[str]:
+        def split_line(text: str) -> list[str]:
             parts = []
             for part in re.split(" |\t", text.strip()):
                 if part == "":

--- a/geolib/models/dfoundations/internal.py
+++ b/geolib/models/dfoundations/internal.py
@@ -1,8 +1,6 @@
 import logging
 from enum import IntEnum
 from inspect import cleandoc
-from typing import Dict, List, Optional, Union
-
 from pydantic import Field, StringConstraints
 from pydantic.types import PositiveInt
 from typing_extensions import Annotated
@@ -111,41 +109,39 @@ class PileShape(IntEnum):
 class TypesBearingPiles(DSeriesNoParseSubStructure):
     pile_name: str = ""
     pile_type: PileType = PileType.PREFABRICATED_CONCRETE_PILE
-    pile_type_for_execution_factor_sand_gravel: Optional[PileType] = None
-    execution_factor_sand_gravel: Optional[Annotated[float, Field(ge=0, le=9)]] = None
-    pile_type_for_execution_factor_clay_loam_peat: Optional[
-        PileTypeForClayLoamPeat
-    ] = None
-    execution_factor_clay_loam_peat: Optional[Annotated[float, Field(ge=0, le=9)]] = None
-    pile_type_for_pile_class_factor: Optional[PileType] = None
-    pile_class_factor: Optional[Annotated[float, Field(ge=0, le=9)]] = None
-    pile_type_for_load_settlement_curve: Optional[LoadSettlementCurve] = None
-    material: Optional[PileMaterial] = None
-    elasticity_modulus: Optional[Annotated[float, Field(ge=0, le=1e25)]] = None
+    pile_type_for_execution_factor_sand_gravel: PileType | None = None
+    execution_factor_sand_gravel: Annotated[float, Field(ge=0, le=9)] | None = None
+    pile_type_for_execution_factor_clay_loam_peat: PileTypeForClayLoamPeat | None = None
+    execution_factor_clay_loam_peat: Annotated[float, Field(ge=0, le=9)] | None = None
+    pile_type_for_pile_class_factor: PileType | None = None
+    pile_class_factor: Annotated[float, Field(ge=0, le=9)] | None = None
+    pile_type_for_load_settlement_curve: LoadSettlementCurve | None = None
+    material: PileMaterial | None = None
+    elasticity_modulus: Annotated[float, Field(ge=0, le=1e25)] | None = None
     slip_layer: BearingPileSlipLayer = BearingPileSlipLayer.NONE
-    characteristic_adhesion: Optional[Annotated[float, Field(ge=0, le=1000)]] = None
+    characteristic_adhesion: Annotated[float, Field(ge=0, le=1000)] | None = None
     shape: PileShape = PileShape.RECTANGULAR_PILE
-    base_width: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_length: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    pile_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_height: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_width_v: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_length_v: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    shaft_width: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    shaft_length: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    increase_in_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    external_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    internal_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    height_h_shape: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    width_h_shape: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    thickness_web: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    thickness_flange: Optional[Annotated[float, Field(ge=0, le=100)]] = None
+    base_width: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_length: Annotated[float, Field(ge=0, le=100)] | None = None
+    diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    pile_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_height: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_width_v: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_length_v: Annotated[float, Field(ge=0, le=100)] | None = None
+    shaft_width: Annotated[float, Field(ge=0, le=100)] | None = None
+    shaft_length: Annotated[float, Field(ge=0, le=100)] | None = None
+    increase_in_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    external_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    internal_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    height_h_shape: Annotated[float, Field(ge=0, le=100)] | None = None
+    width_h_shape: Annotated[float, Field(ge=0, le=100)] | None = None
+    thickness_web: Annotated[float, Field(ge=0, le=100)] | None = None
+    thickness_flange: Annotated[float, Field(ge=0, le=100)] | None = None
     overrule_pile_tip_shape_factor: Bool = Bool.FALSE
-    pile_tip_shape_factor: Optional[Annotated[float, Field(ge=0, le=10)]] = None
+    pile_tip_shape_factor: Annotated[float, Field(ge=0, le=10)] | None = None
     overrule_pile_tip_cross_section_factors: Bool = Bool.FALSE
-    pile_tip_cross_section_factor: Optional[Annotated[float, Field(ge=0, le=10)]] = None
+    pile_tip_cross_section_factor: Annotated[float, Field(ge=0, le=10)] | None = None
     use_pre_2016: Bool = Bool.FALSE
     user_defined_pile_type_as_prefab: Bool = Bool.FALSE
     use_manual_reduction_for_qc: Bool = Bool.FALSE
@@ -156,40 +152,38 @@ class TypesBearingPiles(DSeriesNoParseSubStructure):
 class TypesTensionPiles(DSeriesNoParseSubStructure):
     pile_name: str = ""
     pile_type: PileType = PileType.PREFABRICATED_CONCRETE_PILE
-    pile_type_for_execution_factor_sand_gravel: Optional[PileType] = None
-    execution_factor_sand_gravel: Optional[Annotated[float, Field(ge=0, le=9)]] = None
-    pile_type_for_execution_factor_clay_loam_peat: Optional[
-        PileTypeForClayLoamPeat
-    ] = None
-    execution_factor_clay_loam_peat: Optional[Annotated[float, Field(ge=0, le=9)]] = None
-    material: Optional[PileMaterial] = None
-    unit_weight_pile: Optional[Annotated[float, Field(ge=0, le=1000)]] = None
-    elasticity_modulus: Optional[Annotated[float, Field(ge=0, le=1e25)]] = None
+    pile_type_for_execution_factor_sand_gravel: PileType | None = None
+    execution_factor_sand_gravel: Annotated[float, Field(ge=0, le=9)] | None = None
+    pile_type_for_execution_factor_clay_loam_peat: PileTypeForClayLoamPeat | None = None
+    execution_factor_clay_loam_peat: Annotated[float, Field(ge=0, le=9)] | None = None
+    material: PileMaterial | None = None
+    unit_weight_pile: Annotated[float, Field(ge=0, le=1000)] | None = None
+    elasticity_modulus: Annotated[float, Field(ge=0, le=1e25)] | None = None
     shape: PileShape = PileShape.RECTANGULAR_PILE
-    base_width: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_length: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    pile_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_height: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_width_v: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    base_length_v: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    shaft_width: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    shaft_length: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    increase_in_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    external_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    internal_diameter: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    height_h_shape: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    width_h_shape: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    thickness_web: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    thickness_flange: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    circumference: Optional[Annotated[float, Field(ge=0, le=100)]] = None
-    cross_section: Optional[Annotated[float, Field(ge=0, le=100)]] = None
+    base_width: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_length: Annotated[float, Field(ge=0, le=100)] | None = None
+    diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    pile_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_height: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_width_v: Annotated[float, Field(ge=0, le=100)] | None = None
+    base_length_v: Annotated[float, Field(ge=0, le=100)] | None = None
+    shaft_width: Annotated[float, Field(ge=0, le=100)] | None = None
+    shaft_length: Annotated[float, Field(ge=0, le=100)] | None = None
+    increase_in_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    external_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    internal_diameter: Annotated[float, Field(ge=0, le=100)] | None = None
+    height_h_shape: Annotated[float, Field(ge=0, le=100)] | None = None
+    width_h_shape: Annotated[float, Field(ge=0, le=100)] | None = None
+    thickness_web: Annotated[float, Field(ge=0, le=100)] | None = None
+    thickness_flange: Annotated[float, Field(ge=0, le=100)] | None = None
+    circumference: Annotated[float, Field(ge=0, le=100)] | None = None
+    cross_section: Annotated[float, Field(ge=0, le=100)] | None = None
     is_user_defined: Bool = Bool.TRUE
 
 
 class SoilCollection(DSeriesStructureCollection):
-    soil: List[Soil] = Soil.default_soils()
+    soil: list[Soil] = Soil.default_soils()
 
     def add_soil_if_unique(self, soil) -> None:
         for added_soil in self.soil:
@@ -254,11 +248,11 @@ class Profile(DSeriesTreeStructure):
     excavation_length_infinite: Bool = Bool.TRUE
     distance_edge_pile_to_excavation_boundary: float = 0.0  # only valid for BEGEMANN
 
-    layers: List[Layer] = []
+    layers: list[Layer] = []
 
 
 class Profiles(DSeriesTreeStructureCollection):
-    profiles: List[Profile] = []
+    profiles: list[Profile] = []
 
     def add_profile_if_unique(self, profile: Profile) -> Profile:
         for added_profile in self.profiles:
@@ -310,15 +304,15 @@ class PositionTensionPile(InternalPile):
 
 
 class PositionsBearingPiles(DSeriesNoParseSubStructure):
-    positions: List[PositionBearingPile] = []
+    positions: list[PositionBearingPile] = []
 
 
 class PositionsTensionPiles(DSeriesNoParseSubStructure):
-    positions: List[PositionTensionPile] = []
+    positions: list[PositionTensionPile] = []
 
 
 class CPTMeasureData(DFoundationsTableWrapper):
-    data: List[Dict[str, float]]
+    data: list[dict[str, float]]
 
 
 class ExcavationType(IntEnum):
@@ -407,7 +401,7 @@ class CPT(DFoundationsEnumStructure):
 
 
 class CPTList(DFoundationsCPTCollectionWrapper):
-    cpt_collection: List[CPT] = []
+    cpt_collection: list[CPT] = []
 
     def add_cpt(self, cpt: CPT):
         """Add CPT and return id.
@@ -440,25 +434,25 @@ class CalculationOptions(DSeriesNoParseSubStructure):
 
     # Overrule parameters Bearing Piles
     is_xi3_overruled: Bool = Bool.FALSE
-    factor_xi3: Optional[Annotated[float, Field(ge=0.01, le=10)]] = 2
+    factor_xi3: Annotated[float, Field(ge=0.01, le=10)] | None = 2
     is_xi4_overruled: Bool = Bool.FALSE
-    factor_xi4: Optional[Annotated[float, Field(ge=0.01, le=10)]] = 2
+    factor_xi4: Annotated[float, Field(ge=0.01, le=10)] | None = 2
     is_gamma_b_overruled: Bool = Bool.FALSE
-    factor_gamma_b: Optional[Annotated[float, Field(ge=1, le=100)]] = 2
+    factor_gamma_b: Annotated[float, Field(ge=1, le=100)] | None = 2
     is_gamma_s_overruled: Bool = Bool.FALSE
-    factor_gamma_s: Optional[Annotated[float, Field(ge=1, le=100)]] = 2
+    factor_gamma_s: Annotated[float, Field(ge=1, le=100)] | None = 2
     is_gamma_fnk_overruled: Bool = Bool.FALSE
-    factor_gamma_fnk: Optional[Annotated[float, Field(ge=-100, le=100)]] = 2
+    factor_gamma_fnk: Annotated[float, Field(ge=-100, le=100)] | None = 2
     is_area_overruled: Bool = Bool.FALSE
-    area: Optional[Annotated[float, Field(ge=0, le=100000)]] = 1000
+    area: Annotated[float, Field(ge=0, le=100000)] | None = 1000
     is_qbmax_overruled: Bool = Bool.FALSE
-    qbmax: Optional[Annotated[float, Field(ge=0, le=100)]] = 15
+    qbmax: Annotated[float, Field(ge=0, le=100)] | None = 15
     is_qcza_low_overruled: Bool = Bool.FALSE
-    qcza_low: Optional[Annotated[float, Field(ge=0, le=100)]] = 12
+    qcza_low: Annotated[float, Field(ge=0, le=100)] | None = 12
     is_qcza_high_overruled: Bool = Bool.FALSE
-    qcza_high: Optional[Annotated[float, Field(ge=0, le=100)]] = 15
+    qcza_high: Annotated[float, Field(ge=0, le=100)] | None = 15
     is_ea_gem_overruled: Bool = Bool.FALSE
-    ea_gem: Optional[Annotated[float, Field(ge=1)]] = 100000
+    ea_gem: Annotated[float, Field(ge=1)] | None = 100000
 
     # Model options combined
     is_suppress_qc_reduction: Bool = Bool.FALSE
@@ -471,19 +465,19 @@ class CalculationOptions(DSeriesNoParseSubStructure):
 
     # Overrule parameters Shallow foundations
     is_gamma_g_str_overruled: Bool = Bool.FALSE
-    factor_gamma_g_str: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_g_str: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_coh_overruled: Bool = Bool.FALSE
-    factor_gamma_coh: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_coh: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_phi_overruled: Bool = Bool.FALSE
-    factor_gamma_phi: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_phi: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_fundr_overruled: Bool = Bool.FALSE
-    factor_gamma_fundr: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_fundr: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_g_sls_overruled: Bool = Bool.FALSE
-    factor_gamma_g_sls: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_g_sls: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_cc_overruled: Bool = Bool.FALSE
-    factor_gamma_cc: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_cc: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_ca_overruled: Bool = Bool.FALSE
-    factor_gamma_ca: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_ca: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_keep_length_constant: Bool = Bool.FALSE
     use_5_percent_limit: Bool = Bool.FALSE
     load_factor_between_limit_1_and_2: Annotated[float, Field(ge=0.5, le=1)] = 0.833
@@ -492,11 +486,11 @@ class CalculationOptions(DSeriesNoParseSubStructure):
     unit_weight_water: Annotated[float, Field(ge=0.01, le=20)] = 9.81
     use_compaction: Bool = Bool.FALSE
     is_gamma_var_overruled: Bool = Bool.FALSE
-    factor_gamma_var: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_var: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_st_overruled: Bool = Bool.FALSE
-    factor_gamma_st: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_st: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     is_gamma_gamma_overruled: Bool = Bool.FALSE
-    factor_gamma_gamma: Optional[Annotated[float, Field(ge=0.01, le=100)]] = 1.0
+    factor_gamma_gamma: Annotated[float, Field(ge=0.01, le=100)] | None = 1.0
     surcharge: Annotated[float, Field(ge=0, le=1e7)] = 0
     use_piezometric_levels: Bool = Bool.TRUE
 
@@ -573,15 +567,15 @@ class PreliminaryDesign(DSeriesNoParseSubStructure):
     trajectory_end: float = -25.00
     trajectory_interval: float = 0.50
 
-    profiles: List[int] = []  # ids of Profiles
+    profiles: list[int] = []  # ids of Profiles
     # Can be single pile type only in case of verification
-    pile_types: List[int] = []  # ids of Piles
+    pile_types: list[int] = []  # ids of Piles
 
     # Only valid for Verification Design
-    cpt_test_level: Optional[float] = 0.0  # [m]
+    cpt_test_level: float | None = 0.0  # [m]
 
     # Only valid for Prelimary Design
-    net_bearing_capacity: Optional[int] = 0  # [kN]
+    net_bearing_capacity: int | None = 0  # [kN]
 
 
 class Version(DSerieVersion):
@@ -615,13 +609,13 @@ class DFoundationsInputStructure(DSeriesStructure):
             0 = number of items
         """
     )
-    types___bearing_piles: Union[List[TypesBearingPiles], str] = cleandoc(
+    types___bearing_piles: list[TypesBearingPiles] | str = cleandoc(
         """
         -1 : pile type shown in main graph
             0 = number of items
         """
     )
-    types___tension_piles_cur: Union[List[TypesTensionPiles], str] = cleandoc(
+    types___tension_piles_cur: list[TypesTensionPiles] | str = cleandoc(
         """
         -1 : pile type shown in main graph
             0 = number of items
@@ -637,11 +631,9 @@ class DFoundationsInputStructure(DSeriesStructure):
             0 = number of items
         """
     )
-    positions___bearing_piles: Union[PositionsBearingPiles, str] = PositionsBearingPiles()
+    positions___bearing_piles: PositionsBearingPiles | str = PositionsBearingPiles()
 
-    positions___tension_piles_cur: Union[
-        PositionsTensionPiles, str
-    ] = PositionsTensionPiles()
+    positions___tension_piles_cur: PositionsTensionPiles | str = PositionsTensionPiles()
     positions___shallow_foundations: str = cleandoc(
         """
         [TABLE]
@@ -649,9 +641,9 @@ class DFoundationsInputStructure(DSeriesStructure):
         [END OF TABLE]
         """
     )
-    calculation_options: Union[CalculationOptions, str] = CalculationOptions()
+    calculation_options: CalculationOptions | str = CalculationOptions()
     calculationtype: CalculationType = CalculationType()
-    preliminary_design: Union[PreliminaryDesign, str] = PreliminaryDesign()
+    preliminary_design: PreliminaryDesign | str = PreliminaryDesign()
     location_map: str = cleandoc(
         """
          0.0000
@@ -668,7 +660,7 @@ class DFoundationsInputStructure(DSeriesStructure):
 
 
 class DFoundationsNenPileResultsTable(DFoundationsTableWrapper):
-    data: List[Dict[str, Union[int, float, str]]] = []
+    data: list[dict[str, int | float | str]] = []
 
 
 class DFoundationsCalculationParametersBearingPilesEC7(DSeriesInlineProperties):
@@ -739,14 +731,14 @@ class DFoundationsGlobalNenResults(DFoundationsInlineProperties):
 
 
 class DFoundationsVerificationResults(DSeriesStructure):
-    global_nen_results: Optional[DFoundationsGlobalNenResults] = None
-    demands_nen__en: Optional[str] = None
-    nen_pile_results: Optional[DFoundationsNenPileResults] = None
+    global_nen_results: DFoundationsGlobalNenResults | None = None
+    demands_nen__en: str | None = None
+    nen_pile_results: DFoundationsNenPileResults | None = None
 
-    verification_results_tp_load__settlement_curve_1b: Optional[str] = None
-    verification_results_tp_1a: Optional[str] = None
-    verification_results_tp_1b2: Optional[str] = None
-    verification_results_tp_load__settlement_curve_2: Optional[str] = None
+    verification_results_tp_load__settlement_curve_1b: str | None = None
+    verification_results_tp_1a: str | None = None
+    verification_results_tp_1b2: str | None = None
+    verification_results_tp_load__settlement_curve_2: str | None = None
 
 
 # endregion
@@ -772,23 +764,23 @@ class DFoundationsCalculationWarnings(DSeriesTreeStructure):
 
 
 class DFoundationsDumpfileOutputStructure(DSeriesStructure):
-    results_at_cpt_test_level: Optional[str] = None
-    verification_results: Optional[DFoundationsVerificationResults] = None
+    results_at_cpt_test_level: str | None = None
+    verification_results: DFoundationsVerificationResults | None = None
 
-    calculation_parameters_tension_piles: Optional[str] = None
-    verification_results_tp: Optional[DFoundationsVerificationResults] = None
+    calculation_parameters_tension_piles: str | None = None
+    verification_results_tp: DFoundationsVerificationResults | None = None
 
-    footnote_warnings: Optional[str] = None
-    preliminary_design_results: Optional[str] = None
-    verification_results_sf: Optional[str] = None
-    verification_results_tp_1b2: Optional[str] = None
-    verification_design_results: Optional[str] = None
-    calculation_warnings: Optional[DFoundationsCalculationWarnings] = None
+    footnote_warnings: str | None = None
+    preliminary_design_results: str | None = None
+    verification_results_sf: str | None = None
+    verification_results_tp_1b2: str | None = None
+    verification_design_results: str | None = None
+    calculation_warnings: DFoundationsCalculationWarnings | None = None
 
 
 class DFoundationsStructure(DSeriesStructure):
     input_data: DFoundationsInputStructure = DFoundationsInputStructure()
-    dumpfile_output: Optional[DFoundationsDumpfileOutputStructure] = None
+    dumpfile_output: DFoundationsDumpfileOutputStructure | None = None
 
 
 class DFoundationsDumpStructure(DSeriesStructure):

--- a/geolib/models/dfoundations/internal_soil.py
+++ b/geolib/models/dfoundations/internal_soil.py
@@ -1,7 +1,6 @@
 import logging
 from enum import IntEnum
 from pathlib import Path
-from typing import List
 
 from pydantic import Field, StringConstraints
 from typing_extensions import Annotated
@@ -62,7 +61,7 @@ class Soil(DSeriesUnmappedNameProperties):
         super().__init__(*args, **kwargs)
 
     @classmethod
-    def default_soils(cls, model: str = "BEARING_PILES") -> List["Soil"]:
+    def default_soils(cls, model: str = "BEARING_PILES") -> list["Soil"]:
         currentfolder = Path(__file__).parent
         name = model.lower()
         filename = currentfolder / f"soil_csv/{name}_soils.csv"

--- a/geolib/models/dfoundations/piles.py
+++ b/geolib/models/dfoundations/piles.py
@@ -2,7 +2,6 @@
 
 """
 from enum import Enum
-from typing import Optional
 
 from pydantic import Field, StringConstraints
 from pydantic.types import PositiveInt
@@ -93,9 +92,7 @@ class Pile(BaseDataClass):
     pile_name: str
     pile_type: BasePileType
     pile_class_factor_shaft_sand_gravel: Annotated[float, Field(ge=0, le=9)]
-    pile_class_factor_shaft_clay_loam_peat: Optional[
-        Annotated[float, Field(ge=0, le=9)]
-    ] = None
+    pile_class_factor_shaft_clay_loam_peat: Annotated[float, Field(ge=0, le=9)] | None = None
     preset_pile_class_factor_shaft_clay_loam_peat: BasePileTypeForClayLoamPeat
     elasticity_modulus: Annotated[float, Field(ge=0, le=1e25)]
 
@@ -111,9 +108,9 @@ class BearingPile(Pile):
     characteristic_adhesion: Annotated[float, Field(ge=0, le=1000)]
 
     overrule_pile_tip_shape_factor: bool
-    pile_tip_shape_factor: Optional[Annotated[float, Field(ge=0, le=10)]] = None
+    pile_tip_shape_factor: Annotated[float, Field(ge=0, le=10)] | None = None
     overrule_pile_tip_cross_section_factors: bool
-    pile_tip_cross_section_factor: Optional[Annotated[float, Field(ge=0, le=10)]] = None
+    pile_tip_cross_section_factor: Annotated[float, Field(ge=0, le=10)] | None = None
 
     def _to_internal(self):
         return TypesBearingPiles(

--- a/geolib/models/dfoundations/profiles.py
+++ b/geolib/models/dfoundations/profiles.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from geolib.geometry.one import Point
 from geolib.models import BaseDataClass
@@ -27,7 +27,7 @@ class CPT(BaseDataClass):
     cptname: str
     groundlevel: float
     depthrange: float = 0.10  # minimum layer thickness
-    measured_data: List[Dict[str, float]]
+    measured_data: list[dict[str, float]]
 
     excavation_type: ExcavationType = ExcavationType.BEFORE
     timeorder_type: TimeOrderType = TimeOrderType.CPT_EXCAVATION_INSTALL
@@ -91,7 +91,7 @@ class Profile(BaseDataClass):
     phreatic_level: float
     pile_tip_level: float
     cpt: CPT
-    excavation: Optional[Excavation] = None
+    excavation: Excavation | None = None
     overconsolidation_ratio: float = 1.0
     top_of_positive_skin_friction: float = 0.0
     bottom_of_negative_skin_friction: float = 0.0
@@ -100,7 +100,7 @@ class Profile(BaseDataClass):
     concentration_value_frohlich: int = 3
     top_tension_zone: float = 0.0
     # Any, as combined int, float will become int
-    layers: List[Dict[str, Any]]
+    layers: list[dict[str, Any]]
 
     def _to_internal(self, matching_cpt) -> InternalProfile:
         kwargs = self.model_dump(exclude={"cpt", "excavation", "location"})

--- a/geolib/models/dgeoflow/dgeoflow_model.py
+++ b/geolib/models/dgeoflow/dgeoflow_model.py
@@ -2,7 +2,7 @@ import abc
 import re
 from enum import Enum
 from pathlib import Path
-from typing import BinaryIO, Dict, List, Optional, Set, Type, Union
+from typing import BinaryIO
 
 from pydantic import DirectoryPath, FilePath
 
@@ -54,7 +54,7 @@ class DGeoFlowModel(BaseModel):
         self.current_id = self.datastructure.get_unique_id()
 
     @property
-    def parser_provider_type(self) -> Type[DGeoFlowParserProvider]:
+    def parser_provider_type(self) -> type[DGeoFlowParserProvider]:
         return DGeoFlowParserProvider
 
     @property
@@ -66,7 +66,7 @@ class DGeoFlowModel(BaseModel):
         return self.get_meta_property("dgeoflow_console_path")
 
     @property
-    def console_flags_post(self) -> List[str]:
+    def console_flags_post(self) -> list[str]:
         return [
             str(self.current_scenario_index + 1),
             str(self.current_calculation_index + 1),
@@ -99,7 +99,7 @@ class DGeoFlowModel(BaseModel):
             self.current_scenario_index, self.current_calculation_index
         )
 
-    def get_result(self, scenario_index: int, calculation_index: int) -> Dict:
+    def get_result(self, scenario_index: int, calculation_index: int) -> dict:
         """
         Returns the results of a scenario. Calculation results are based on analysis type and calculation type.
 
@@ -133,7 +133,7 @@ class DGeoFlowModel(BaseModel):
 
         raise ValueError(f"No result found for result id {scenario_index}")
 
-    def serialize(self, location: Union[FilePath, DirectoryPath, BinaryIO]):
+    def serialize(self, location: FilePath | DirectoryPath | BinaryIO):
         """Support serializing to directory while developing for debugging purposes."""
         if isinstance(location, Path) and location.is_dir():
             serializer = DGeoFlowInputSerializer(ds=self.datastructure)
@@ -193,7 +193,7 @@ class DGeoFlowModel(BaseModel):
 
     def add_layer(
         self,
-        points: List[Point],
+        points: list[Point],
         soil_code: str,
         label: str = "",
         notes: str = "",
@@ -203,7 +203,7 @@ class DGeoFlowModel(BaseModel):
         Add a soil layer to the model
 
         Args:
-            points (List[Point]): list of Point classes, in clockwise order (non closed simple polygon)
+            points (list[Point]): list of Point classes, in clockwise order (non closed simple polygon)
             soil_code (str): code of the soil for this layer
             label (str): label defaults to empty string
             notes (str): notes defaults to empty string
@@ -267,7 +267,7 @@ class DGeoFlowModel(BaseModel):
 
     def add_boundary_condition(
         self,
-        points: List[Point],
+        points: list[Point],
         head_level: float,
         label: str = "",
         notes: str = "",
@@ -277,7 +277,7 @@ class DGeoFlowModel(BaseModel):
         Add boundary conditions to the model
 
         Args:
-            points (List[Point]): list of Point classes, in clockwise order (non closed simple polygon)
+            points (list[Point]): list of Point classes, in clockwise order (non closed simple polygon)
             head_level (float): level of the hydraulic head for the boundary condition
             label (str): label defaults to empty string
             notes (str): notes defaults to empty string
@@ -297,7 +297,7 @@ class DGeoFlowModel(BaseModel):
         return boundary_condition_id
 
     @property
-    def scenarios(self) -> List[Scenario]:
+    def scenarios(self) -> list[Scenario]:
         return self.datastructure.scenarios
 
     def add_scenario(
@@ -328,7 +328,7 @@ class DGeoFlowModel(BaseModel):
 
     def add_stage(
         self,
-        scenario_index: Optional[int] = None,
+        scenario_index: int | None = None,
         label: str = "Stage",
         notes: str = "",
         set_current=True,
@@ -359,7 +359,7 @@ class DGeoFlowModel(BaseModel):
 
     def add_calculation(
         self,
-        scenario_index: Optional[int] = None,
+        scenario_index: int | None = None,
         label: str = "Calculation",
         notes: str = "",
         set_current: bool = True,

--- a/geolib/models/dgeoflow/dgeoflow_parserprovider.py
+++ b/geolib/models/dgeoflow/dgeoflow_parserprovider.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Tuple, Type, _GenericAlias
+from typing import _GenericAlias
 from zipfile import ZipFile
 
 from pydantic import DirectoryPath, FilePath
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 class DGeoFlowParser(BaseParser):
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".json", ""]
 
     @property
-    def structure(self) -> Type[DGeoFlowStructure]:
+    def structure(self) -> type[DGeoFlowStructure]:
         return DGeoFlowStructure
 
     def can_parse(self, filename: FilePath) -> bool:
@@ -44,7 +44,7 @@ class DGeoFlowParser(BaseParser):
 
         return self.structure(**data_structure)
 
-    def __parse_folder(self, fieldtype, filepath: DirectoryPath) -> List:
+    def __parse_folder(self, fieldtype, filepath: DirectoryPath) -> list:
         out = []
         folder = filepath / fieldtype.structure_group()
 
@@ -67,7 +67,7 @@ class DGeoFlowParser(BaseParser):
 
 class DGeoFlowZipParser(DGeoFlowParser):
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".flox"]
 
     def can_parse(self, filename: FilePath) -> bool:
@@ -95,13 +95,13 @@ class DGeoFlowParserProvider(BaseParserProvider):
     _output_parsers = None
 
     @property
-    def input_parsers(self) -> Tuple[DGeoFlowParser, DGeoFlowZipParser]:
+    def input_parsers(self) -> tuple[DGeoFlowParser, DGeoFlowZipParser]:
         if not self._input_parsers:
             self._input_parsers = (DGeoFlowZipParser(), DGeoFlowParser())
         return self._input_parsers
 
     @property
-    def output_parsers(self) -> Tuple[DGeoFlowParser, DGeoFlowZipParser]:
+    def output_parsers(self) -> tuple[DGeoFlowParser, DGeoFlowZipParser]:
         if not self._output_parsers:
             self._output_parsers = (DGeoFlowParser(), DGeoFlowZipParser())
         return self._output_parsers

--- a/geolib/models/dgeoflow/dgeoflow_validator.py
+++ b/geolib/models/dgeoflow/dgeoflow_validator.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Set
 
 from geolib.models.validators import BaseValidator
 

--- a/geolib/models/dgeoflow/internal.py
+++ b/geolib/models/dgeoflow/internal.py
@@ -7,7 +7,6 @@ from datetime import date, datetime
 from enum import Enum
 from itertools import chain
 from math import isfinite
-from typing import Dict, List, Optional, Set, Tuple, Union
 
 from pydantic import ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Annotated
@@ -78,16 +77,16 @@ class PersistableShadingTypeEnum(Enum):
 
 
 class PersistableSoilVisualization(DGeoFlowBaseModelStructure):
-    Color: Optional[str]
-    PersistableShadingType: Optional[PersistableShadingTypeEnum]
-    SoilId: Optional[str]
+    Color: str | None
+    PersistableShadingType: PersistableShadingTypeEnum | None
+    SoilId: str | None
 
     id_validator = field_validator("SoilId", mode="before")(transform_id_to_str)
 
 
 class SoilVisualisation(DGeoFlowBaseModelStructure):
-    ContentVersion: Optional[str] = "2"
-    SoilVisualizations: Optional[List[Optional[PersistableSoilVisualization]]] = []
+    ContentVersion: str | None = "2"
+    SoilVisualizations: list[PersistableSoilVisualization | None] | None = []
 
     @classmethod
     def structure_name(cls) -> str:
@@ -95,8 +94,8 @@ class SoilVisualisation(DGeoFlowBaseModelStructure):
 
 
 class PersistableSoilLayer(DGeoFlowBaseModelStructure):
-    LayerId: Optional[str] = None
-    SoilId: Optional[str] = None
+    LayerId: str | None = None
+    SoilId: str | None = None
 
     id_validator = field_validator("LayerId", "SoilId", mode="before")(
         transform_id_to_str
@@ -114,9 +113,9 @@ class SoilLayerCollection(DGeoFlowSubStructure):
     def structure_group(cls) -> str:
         return "soillayers"
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    SoilLayers: List[PersistableSoilLayer] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    SoilLayers: list[PersistableSoilLayer] = []
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -125,7 +124,7 @@ class SoilLayerCollection(DGeoFlowSubStructure):
         self.SoilLayers.append(psl)
         return psl
 
-    def get_ids(self, exclude_soil_layer_id: Optional[int]) -> Set[str]:
+    def get_ids(self, exclude_soil_layer_id: int | None) -> set[str]:
         if exclude_soil_layer_id is not None:
             exclude_soil_layer_id = str(exclude_soil_layer_id)
         return {
@@ -149,8 +148,8 @@ class PersistableSoil(DGeoFlowBaseModelStructure):
 class SoilCollection(DGeoFlowSubStructure):
     """soils.json"""
 
-    ContentVersion: Optional[str] = "2"
-    Soils: List[PersistableSoil] = [
+    ContentVersion: str | None = "2"
+    Soils: list[PersistableSoil] = [
         PersistableSoil(
             Code="H_Aa_ht_new",
             Id="2",
@@ -317,7 +316,7 @@ class SoilCollection(DGeoFlowSubStructure):
         raise ValueError(f"Soil code '{code}' not found in the SoilCollection")
 
     def edit_soil_by_name(
-        self, name: Optional[str] = None, **kwargs: dict
+        self, name: str | None = None, **kwargs: dict
     ) -> PersistableSoil:
         """
         Update a soil, searching by name. This method will edit the first occurence of the name
@@ -353,22 +352,22 @@ class SoilCollection(DGeoFlowSubStructure):
 class ProjectInfo(DGeoFlowSubStructure):
     """projectinfo.json."""
 
-    Analyst: Optional[str] = ""
-    ApplicationCreated: Optional[str] = ""
-    ApplicationModified: Optional[str] = ""
-    ContentVersion: Optional[str] = "2"
-    Created: Optional[date] = datetime.now().date()
-    CrossSection: Optional[str] = ""
-    Date: Optional[date] = datetime.now().date()
-    IsDataValidated: Optional[bool] = False
-    LastModified: Optional[date] = datetime.now().date()
-    LastModifier: Optional[str] = "GEOLib"
-    Path: Optional[str] = ""
-    Project: Optional[str] = ""
-    Remarks: Optional[str] = f"Created with GEOLib {version}"
+    Analyst: str | None = ""
+    ApplicationCreated: str | None = ""
+    ApplicationModified: str | None = ""
+    ContentVersion: str | None = "2"
+    Created: date | None = datetime.now().date()
+    CrossSection: str | None = ""
+    Date: date | None = datetime.now().date()
+    IsDataValidated: bool | None = False
+    LastModified: date | None = datetime.now().date()
+    LastModifier: str | None = "GEOLib"
+    Path: str | None = ""
+    Project: str | None = ""
+    Remarks: str | None = f"Created with GEOLib {version}"
 
     @classmethod
-    def nltime(cls, date: Union[date, str]) -> date:
+    def nltime(cls, date: date | str) -> date:
         if isinstance(date, str):
             position = date.index(max(date.split("-"), key=len))
             if position > 0:
@@ -383,15 +382,15 @@ class ProjectInfo(DGeoFlowSubStructure):
 
 
 class PersistablePoint(DGeoFlowBaseModelStructure):
-    X: Optional[float] = 0
-    Z: Optional[float] = 0
+    X: float | None = 0
+    Z: float | None = 0
 
 
 class PersistableLayer(DGeoFlowBaseModelStructure):
-    Id: Optional[str] = None
-    Label: Optional[str] = None
-    Notes: Optional[str] = None
-    Points: Annotated[List[PersistablePoint], Field(min_length=3)]
+    Id: str | None = None
+    Label: str | None = None
+    Notes: str | None = None
+    Points: Annotated[list[PersistablePoint], Field(min_length=3)]
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -422,9 +421,9 @@ class Geometry(DGeoFlowSubStructure):
     def structure_name(cls) -> str:
         return "geometry"
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    Layers: List[PersistableLayer] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    Layers: list[PersistableLayer] = []
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -456,7 +455,7 @@ class Geometry(DGeoFlowSubStructure):
         raise ValueError(f"Layer id {id} not found in this geometry")
 
     def add_layer(
-        self, id: str, label: str, notes: str, points: List[Point]
+        self, id: str, label: str, notes: str, points: list[Point]
     ) -> PersistableLayer:
         """
         Add a new layer to the model. Layers are expected;
@@ -468,7 +467,7 @@ class Geometry(DGeoFlowSubStructure):
             id (str): id of the layer
             label (str): label of the layer
             notes (str): notes for the layers
-            points (List[Points]): list of Point classes
+            points (list[Points]): list of Point classes
 
         Returns:
             PersistableLayer: the layer as a persistable object
@@ -489,10 +488,10 @@ class PersistableFixedHeadBoundaryConditionProperties(DGeoFlowBaseModelStructure
 
 
 class PersistableBoundaryCondition(DGeoFlowBaseModelStructure):
-    Label: Optional[str] = None
-    Notes: Optional[str] = None
-    Id: Optional[str] = None
-    Points: Annotated[List[PersistablePoint], Field(min_length=2)]
+    Label: str | None = None
+    Notes: str | None = None
+    Id: str | None = None
+    Points: Annotated[list[PersistablePoint], Field(min_length=2)]
     FixedHeadBoundaryConditionProperties: PersistableFixedHeadBoundaryConditionProperties
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
@@ -501,9 +500,9 @@ class PersistableBoundaryCondition(DGeoFlowBaseModelStructure):
 class BoundaryConditionCollection(DGeoFlowSubStructure):
     """boundaryconditions/boundaryconditions_x.json"""
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    BoundaryConditions: List[PersistableBoundaryCondition] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    BoundaryConditions: list[PersistableBoundaryCondition] = []
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -536,7 +535,7 @@ class BoundaryConditionCollection(DGeoFlowSubStructure):
         return False
 
     def add_boundary_condition(
-        self, id: int, label: str, notes: str, points: List[Point], head_level: float
+        self, id: int, label: str, notes: str, points: list[Point], head_level: float
     ) -> PersistableBoundaryCondition:
         pbc_properties = PersistableFixedHeadBoundaryConditionProperties(
             HeadLevel=head_level
@@ -553,9 +552,9 @@ class BoundaryConditionCollection(DGeoFlowSubStructure):
 
 
 class PersistableStage(DGeoFlowBaseModelStructure):
-    Label: Optional[str] = None
-    Notes: Optional[str] = None
-    BoundaryConditionCollectionId: Optional[str] = None
+    Label: str | None = None
+    Notes: str | None = None
+    BoundaryConditionCollectionId: str | None = None
 
 
 class ErosionDirectionEnum(Enum):
@@ -564,31 +563,31 @@ class ErosionDirectionEnum(Enum):
 
 
 class InternalPipeTrajectory(DGeoFlowBaseModelStructure):
-    Label: Optional[str] = None
-    Notes: Optional[str] = None
-    D70: Optional[float] = None
-    Points: Optional[List[PersistablePoint]] = None
-    ErosionDirection: Optional[ErosionDirectionEnum] = ErosionDirectionEnum.RIGHT_TO_LEFT
-    ElementSize: Optional[float] = None
+    Label: str | None = None
+    Notes: str | None = None
+    D70: float | None = None
+    Points: list[PersistablePoint] | None = None
+    ErosionDirection: ErosionDirectionEnum | None = ErosionDirectionEnum.RIGHT_TO_LEFT
+    ElementSize: float | None = None
 
 
 class PersistableCriticalHeadSearchSpace(DGeoFlowBaseModelStructure):
-    MinimumHeadLevel: Optional[float] = 0
-    MaximumHeadLevel: Optional[float] = 1
-    StepSize: Optional[float] = 0.1
+    MinimumHeadLevel: float | None = 0
+    MaximumHeadLevel: float | None = 1
+    StepSize: float | None = 0.1
 
 
 class PersistableCalculation(DGeoFlowBaseModelStructure):
-    Label: Optional[str] = None
-    Notes: Optional[str] = None
-    CalculationType: Optional[CalculationTypeEnum] = CalculationTypeEnum.GROUNDWATER_FLOW
-    CriticalHeadId: Optional[str] = None
-    CriticalHeadSearchSpace: Optional[PersistableCriticalHeadSearchSpace] = (
+    Label: str | None = None
+    Notes: str | None = None
+    CalculationType: CalculationTypeEnum | None = CalculationTypeEnum.GROUNDWATER_FLOW
+    CriticalHeadId: str | None = None
+    CriticalHeadSearchSpace: PersistableCriticalHeadSearchSpace | None = (
         PersistableCriticalHeadSearchSpace()
     )
-    PipeTrajectory: Optional[InternalPipeTrajectory] = None
-    MeshPropertiesId: Optional[str] = None
-    ResultsId: Optional[str] = None
+    PipeTrajectory: InternalPipeTrajectory | None = None
+    MeshPropertiesId: str | None = None
+    ResultsId: str | None = None
 
     id_validator = field_validator(
         "CriticalHeadId", "MeshPropertiesId", "ResultsId", mode="before"
@@ -596,32 +595,32 @@ class PersistableCalculation(DGeoFlowBaseModelStructure):
 
 
 class NodeResult(DGeoFlowBaseModelStructure):
-    Point: Optional[PersistablePoint] = None
+    Point: PersistablePoint | None = None
     TotalPorePressure: float = 1
     HydraulicDischarge: float = 1
     HydraulicHead: float = 1
 
 
 class ElementResult(DGeoFlowBaseModelStructure):
-    NodeResults: Optional[List[NodeResult]] = []
+    NodeResults: list[NodeResult] | None = []
 
 
 class PersistablePhreaticLineSegment(DGeoFlowBaseModelStructure):
-    Start: Optional[PersistablePoint] = None
-    End: Optional[PersistablePoint] = None
+    Start: PersistablePoint | None = None
+    End: PersistablePoint | None = None
 
 
 class PipeElementResult(DGeoFlowBaseModelStructure):
-    Nodes: Optional[List[PersistablePoint]] = []
-    IsActive: Optional[bool] = None
-    Height: Optional[float] = None
+    Nodes: list[PersistablePoint] | None = []
+    IsActive: bool | None = None
+    Height: float | None = None
 
 
 class GroundwaterFlowResult(DGeoFlowSubStructure):
-    Id: Optional[str] = None
-    Elements: Optional[List[ElementResult]] = []
-    PhreaticLineSegments: Optional[List[PersistablePhreaticLineSegment]] = []
-    ContentVersion: Optional[str] = "2"
+    Id: str | None = None
+    Elements: list[ElementResult] | None = []
+    PhreaticLineSegments: list[PersistablePhreaticLineSegment] | None = []
+    ContentVersion: str | None = "2"
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -631,12 +630,12 @@ class GroundwaterFlowResult(DGeoFlowSubStructure):
 
 
 class PipeLengthResult(DGeoFlowSubStructure):
-    Id: Optional[str] = None
-    PipeLength: Optional[float] = None
-    Elements: Optional[List[ElementResult]] = []
-    PhreaticLineSegments: Optional[List[PersistablePhreaticLineSegment]] = []
-    PipeElements: Optional[List[PipeElementResult]] = []
-    ContentVersion: Optional[str] = "2"
+    Id: str | None = None
+    PipeLength: float | None = None
+    Elements: list[ElementResult] | None = []
+    PhreaticLineSegments: list[PersistablePhreaticLineSegment] | None = []
+    PipeElements: list[PipeElementResult] | None = []
+    ContentVersion: str | None = "2"
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -646,13 +645,13 @@ class PipeLengthResult(DGeoFlowSubStructure):
 
 
 class CriticalHeadResult(DGeoFlowSubStructure):
-    Id: Optional[str] = None
-    PipeLength: Optional[float] = None
-    CriticalHead: Optional[float] = None
-    Elements: Optional[List[ElementResult]] = []
-    PhreaticLineSegments: Optional[List[PersistablePhreaticLineSegment]] = []
-    PipeElements: Optional[List[PipeElementResult]] = []
-    ContentVersion: Optional[str] = "2"
+    Id: str | None = None
+    PipeLength: float | None = None
+    CriticalHead: float | None = None
+    Elements: list[ElementResult] | None = []
+    PhreaticLineSegments: list[PersistablePhreaticLineSegment] | None = []
+    PipeElements: list[PipeElementResult] | None = []
+    ContentVersion: str | None = "2"
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -661,20 +660,20 @@ class CriticalHeadResult(DGeoFlowSubStructure):
         return "results/criticalhead/"
 
 
-DGeoFlowResult = Union[GroundwaterFlowResult, PipeLengthResult, CriticalHeadResult]
+DGeoFlowResult = GroundwaterFlowResult | PipeLengthResult | CriticalHeadResult
 
 
 class Scenario(DGeoFlowSubStructure):
     """scenarios/scenario_x.json"""
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    Label: Optional[str] = None
-    Notes: Optional[str] = None
-    GeometryId: Optional[str] = None
-    SoilLayersId: Optional[str] = None
-    Stages: List[PersistableStage] = []
-    Calculations: List[PersistableCalculation] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    Label: str | None = None
+    Notes: str | None = None
+    GeometryId: str | None = None
+    SoilLayersId: str | None = None
+    Stages: list[PersistableStage] = []
+    Calculations: list[PersistableCalculation] = []
 
     id_validator = field_validator("Id", "GeometryId", "SoilLayersId", mode="before")(
         transform_id_to_str
@@ -711,8 +710,8 @@ class Scenario(DGeoFlowSubStructure):
 
 class PersistableMeshProperties(DGeoFlowBaseModelStructure):
     LayerId: str
-    Label: Optional[str] = None
-    ElementSize: Optional[float] = 1
+    Label: str | None = None
+    ElementSize: float | None = 1
 
     id_validator = field_validator("LayerId", mode="before")(transform_id_to_str)
 
@@ -720,9 +719,9 @@ class PersistableMeshProperties(DGeoFlowBaseModelStructure):
 class MeshProperty(DGeoFlowSubStructure):
     """meshproperties/meshproperties_x.json"""
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    MeshProperties: Optional[List[PersistableMeshProperties]] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    MeshProperties: list[PersistableMeshProperties] | None = []
 
     id_validator = field_validator("Id", mode="before")(transform_id_to_str)
 
@@ -743,7 +742,7 @@ class MeshProperty(DGeoFlowSubStructure):
         self.MeshProperties.append(pmp)
         return pmp
 
-    def get_ids(self, exclude_soil_layer_id: Optional[int]) -> Set[str]:
+    def get_ids(self, exclude_soil_layer_id: int | None) -> set[str]:
         if exclude_soil_layer_id is not None:
             exclude_soil_layer_id = str(exclude_soil_layer_id)
         return {
@@ -756,7 +755,7 @@ class MeshProperty(DGeoFlowSubStructure):
 class DGeoFlowStructure(BaseModelStructure):
     """Highest level DGeoFlow class that should be parsed to and serialized from.
 
-    The List[] items (one for each scenario in the model) will be stored in a subfolder
+    The list[] items (one for each scenario in the model) will be stored in a subfolder
     to multiple json files. Where the first (0) instance
     has no suffix, but the second one has (1 => _1) etc.
 
@@ -764,19 +763,19 @@ class DGeoFlowStructure(BaseModelStructure):
     """
 
     # input part
-    soillayers: List[SoilLayerCollection] = [
+    soillayers: list[SoilLayerCollection] = [
         SoilLayerCollection(Id="14")
     ]  # soillayers/soillayers_x.json
     soils: SoilCollection = SoilCollection()  # soils.json
     soilvisualizations: SoilVisualisation = SoilVisualisation()  # soilvisualizations.json
 
     projectinfo: ProjectInfo = ProjectInfo()  # projectinfo.json
-    geometries: List[Geometry] = [Geometry(Id="1")]  # geometries/geometry_x.json
+    geometries: list[Geometry] = [Geometry(Id="1")]  # geometries/geometry_x.json
 
-    boundary_conditions: List[BoundaryConditionCollection] = [
+    boundary_conditions: list[BoundaryConditionCollection] = [
         BoundaryConditionCollection(Id="15")
     ]  # boundaryconditions/boundaryconditions_x.json
-    scenarios: List[Scenario] = [
+    scenarios: list[Scenario] = [
         Scenario(
             Id="0",
             Label="Scenario 1",
@@ -790,20 +789,20 @@ class DGeoFlowStructure(BaseModelStructure):
             ],
         )
     ]  # scenarios/scenario_x.json
-    mesh_properties: List[MeshProperty] = [
+    mesh_properties: list[MeshProperty] = [
         MeshProperty(Id="16", MeshProperties=[])
     ]  # meshproperties/meshproperties_x.json
 
     # Output parts
-    groundwater_flow_results: List[GroundwaterFlowResult] = []
-    pipe_length_results: List[PipeLengthResult] = []
-    critical_head_results: List[CriticalHeadResult] = []
+    groundwater_flow_results: list[GroundwaterFlowResult] = []
+    pipe_length_results: list[PipeLengthResult] = []
+    critical_head_results: list[CriticalHeadResult] = []
 
     model_config = ConfigDict(arbitrary_types_allowed=True, validate_assignment=True)
 
     def get_result_substructure(
         self, calculation_type: CalculationTypeEnum
-    ) -> List[DGeoFlowResult]:
+    ) -> list[DGeoFlowResult]:
         result_types_mapping = {
             CalculationTypeEnum.GROUNDWATER_FLOW: self.groundwater_flow_results,
             CalculationTypeEnum.PIPE_LENGTH: self.pipe_length_results,
@@ -836,8 +835,8 @@ class DGeoFlowStructure(BaseModelStructure):
         return self
 
     def add_default_scenario(
-        self, label: str, notes: str, unique_start_id: Optional[int] = None
-    ) -> Tuple[int, int]:
+        self, label: str, notes: str, unique_start_id: int | None = None
+    ) -> tuple[int, int]:
         """Add a new default (empty) scenario to DGeoFlow."""
         if unique_start_id is None:
             unique_start_id = self.get_unique_id()
@@ -874,7 +873,7 @@ class DGeoFlowStructure(BaseModelStructure):
         scenario_index: int,
         label: str,
         notes: str,
-        unique_start_id: Optional[int] = None,
+        unique_start_id: int | None = None,
     ) -> int:
         """Add a new default (empty) stage to DStability."""
         if unique_start_id is None:
@@ -980,7 +979,7 @@ class ForeignKeys(DGeoFlowBaseModelStructure):
     as (implicit) foreign keys.
     """
 
-    mapping: Dict[str, Tuple[str, ...]] = {
+    mapping: dict[str, tuple[str, ...]] = {
         "PersistableSoil.Id": (
             "PersistableSoilVisualization.SoilId",
             "PersistableSoilLayer.SoilId",
@@ -999,7 +998,7 @@ class ForeignKeys(DGeoFlowBaseModelStructure):
     }
 
     @property
-    def class_fields(self) -> Dict[str, List[str]]:
+    def class_fields(self) -> dict[str, list[str]]:
         """Return a mapping in the form:
         classname: [fields]
         """

--- a/geolib/models/dgeoflow/serializer.py
+++ b/geolib/models/dgeoflow/serializer.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from io import BytesIO
-from typing import Dict, Union, _GenericAlias
+from typing import _GenericAlias
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from pydantic import DirectoryPath, FilePath
@@ -17,8 +17,8 @@ class DGeoFlowBaseSerializer(BaseSerializer, metaclass=ABCMeta):
 
     ds: DGeoFlowStructure
 
-    def serialize(self) -> Dict:
-        serialized_datastructure: Dict = {}
+    def serialize(self) -> dict:
+        serialized_datastructure: dict = {}
 
         for field, fieldtype in get_filtered_type_hints(self.ds):
             # On List types, write a folder
@@ -70,7 +70,7 @@ class DGeoFlowInputSerializer(DGeoFlowBaseSerializer):
 class DGeoFlowInputZipSerializer(DGeoFlowBaseSerializer):
     """DStabilSerializer for zipped.stix files."""
 
-    def write(self, filepath: Union[FilePath, BytesIO]) -> Union[FilePath, BytesIO]:
+    def write(self, filepath: FilePath | BytesIO) -> FilePath | BytesIO:
         with ZipFile(filepath, mode="w", compression=ZIP_DEFLATED) as zip:
             serialized_datastructure = self.serialize()
 

--- a/geolib/models/dseries_parser.py
+++ b/geolib/models/dseries_parser.py
@@ -7,7 +7,7 @@ import shlex
 from abc import abstractmethod
 from itertools import groupby
 from math import isfinite
-from typing import Dict, Iterable, List, Tuple, Type, Union, get_type_hints
+from typing import Iterable, get_type_hints
 
 from pydantic import FilePath
 
@@ -40,7 +40,7 @@ class DSeriesStructure(BaseModelStructure):
         When we have a class:
         ```
         Test(DSeriesStructure):
-            field_a: Union[OtherClass, str]
+            field_a: OtherClass | str
         ```
         and we receive field_a as a `str`, we check the attributes
         of `OtherClass` to see if it (also) has a `is_parseable` method.
@@ -49,10 +49,6 @@ class DSeriesStructure(BaseModelStructure):
 
         If `OtherClass` is a child of `DSeriesStructure`, this process
         is recursive.
-
-        Note that the heuristics of checking type hints such as
-        `Optional` and `List` or `Union` are still archaic.
-        In later versions of Python this is improved.
         """
         # Remove fields that are None so defaults will be used
         kwargs = {field: value for field, value in kwargs.items() if value is not None}
@@ -87,7 +83,7 @@ class DSeriesStructure(BaseModelStructure):
                     if DataClass in fieldtype.__mro__:
                         logger.debug(f"Can't parse {fieldtype} for {field} yet")
 
-            # If the body is a List[string], we should check
+            # If the body is a list[string], we should check
             # whether we can parse it further.
             elif (
                 field in kwargs
@@ -145,12 +141,12 @@ class DSeriesStructure(BaseModelStructure):
         return cls(**parsed_structure)
 
     @classmethod
-    def get_structure_required_fields(cls) -> List[Tuple[str, Type]]:
+    def get_structure_required_fields(cls) -> list[tuple[str, type]]:
         """Allows concrete classes to filter out fields that would normally be
         parsed.
 
         Returns:
-            List[Tuple[str, Type]]: List of Tuples[FieldName, FieldType]
+            list[tuple[str, type]]: List of Tuples[FieldName, FieldType]
         """
         return get_filtered_type_hints(cls)
 
@@ -267,11 +263,11 @@ class DSeriesTableStructure(DSeriesStructure):
         return cls(**d)
 
     @classmethod
-    def validate_number_of_rows(cls, lines: List[List[str]]):
+    def validate_number_of_rows(cls, lines: list[list[str]]):
         """Validates whether the number of lines matched the expected rows to be read.
 
         Args:
-            lines (List[List[str]]): Lines representing rows of data.
+            lines (list[list[str]]): Lines representing rows of data.
         Raises:
             ParserError: When the expectations are not met.
         """
@@ -289,7 +285,7 @@ class DSeriesWrappedTableStructure(DSeriesTableStructure):
         contained in the file. Therefore they are not validated.
 
         Args:
-            lines (List[str]): Parsed rows.
+            lines (list[str]): Parsed rows.
         """
         pass
 
@@ -318,7 +314,7 @@ class DSeriesWrappedTableStructure(DSeriesTableStructure):
 
         # Changed this code to keep the type of the parsed data. This is needed for the
         # tests to pass. Assert does not do type coercion, so asser '7' == 7 will fail.
-        def split_line(text: str) -> List[str]:
+        def split_line(text: str) -> list[str]:
             parts = []
             for part in re.split("[ \t]", text.strip()):
                 if part == "":
@@ -441,7 +437,7 @@ class DSerieListStructure(DSeriesStructure):
         return cls(**d)
 
     @classmethod
-    def parse_text_lines(cls, lines: List[List[str]]):
+    def parse_text_lines(cls, lines: list[list[str]]):
         d = {cls.__name__.lower(): [line[0] for line in lines]}
         return cls(**d), 1
 
@@ -511,7 +507,7 @@ class DSeriesInlineProperties(DSeriesStructure):
         return 0
 
     @classmethod
-    def get_property_key_value(cls, text: str, expected_property: str) -> Tuple[str, str]:
+    def get_property_key_value(cls, text: str, expected_property: str) -> tuple[str, str]:
         """Gets the property key and value for a given text line.
         It allows concrete classes to override it and either use the expected property
         name or another value.
@@ -521,7 +517,7 @@ class DSeriesInlineProperties(DSeriesStructure):
             expected_property (str): The expected property key if parsing the structure properties in order.
 
         Returns:
-            Tuple[str, str]: Property name and property value text.
+            tuple[str, str]: Property name and property value text.
         """
         # If there's no key it's because this is actually a property,
         # the real key and values are stored in the second item of the tuple.
@@ -601,7 +597,7 @@ class DSeriesInlineMappedProperties(DSeriesInlineProperties):
     """
 
     @classmethod
-    def get_property_key_value(cls, text: str, expected_property: str) -> Tuple[str, str]:
+    def get_property_key_value(cls, text: str, expected_property: str) -> tuple[str, str]:
         """Gets both property key and value from the text line.
 
         Args:
@@ -609,7 +605,7 @@ class DSeriesInlineMappedProperties(DSeriesInlineProperties):
             expected_property (str): The expected property if there was no key.
 
         Returns:
-            Tuple[str, str]: Parsed key and value.
+            tuple[str, str]: Parsed key and value.
         """
         key = expected_property
         unformatted_key, value = get_line_property_key_value(text, reversed_key=False)
@@ -632,7 +628,7 @@ class DSerieVersion(DSeriesInlineMappedProperties):
 
 class DSeriesInlineReversedProperties(DSeriesInlineProperties):
     @classmethod
-    def get_property_key_value(cls, text: str, expected_property: str) -> Tuple[str, str]:
+    def get_property_key_value(cls, text: str, expected_property: str) -> tuple[str, str]:
         """Returns the value content for a line of format:
         value : key || value = key
 
@@ -669,7 +665,7 @@ class DSeriesUnmappedNameProperties(DSeriesInlineMappedProperties):
     """
 
     @classmethod
-    def get_property_key_value(cls, text: str, expected_property: str) -> Tuple[str, str]:
+    def get_property_key_value(cls, text: str, expected_property: str) -> tuple[str, str]:
         """Gets both property key and value from the text line.
 
         Args:
@@ -677,7 +673,7 @@ class DSeriesUnmappedNameProperties(DSeriesInlineMappedProperties):
             expected_property (str): The expected property if there was no key.
 
         Returns:
-            Tuple[str, str]: Parsed key and value.
+            tuple[str, str]: Parsed key and value.
         """
 
         if expected_property == "name":
@@ -800,12 +796,12 @@ class DSeriesRepeatedGroupedProperties(DSeriesStructure):
         return group_key in cls.get_list_field_names()
 
     @classmethod
-    def get_list_field_names(cls) -> List[str]:
+    def get_list_field_names(cls) -> list[str]:
         """Returns the field names which are typed as list.
         Allows for extension on concrete classes.
 
         Returns:
-            List[str]: List of field names.
+            list[str]: List of field names.
         """
         return [
             field_name
@@ -814,13 +810,13 @@ class DSeriesRepeatedGroupedProperties(DSeriesStructure):
         ]
 
     @classmethod
-    def get_inline_properties(cls, inline_properties: List[str]) -> Dict[str, str]:
+    def get_inline_properties(cls, inline_properties: list[str]) -> dict[str, str]:
         """Processes all unmapped properties and returns them in a dictionary.
         This method can be replaced in concrete implementations of this class.
         Args:
-            inline_properties (List[str]): List of property values which key was not found.
+            inline_properties (list[str]): List of property values which key was not found.
         Returns:
-            Dict[str, str]: Returns a dictionary of inline properties.
+            dict[str, str]: Returns a dictionary of inline properties.
         """
         logger.debug(
             "The following properties were not mapped because no key was found for them:"
@@ -830,31 +826,31 @@ class DSeriesRepeatedGroupedProperties(DSeriesStructure):
         return {}
 
     @classmethod
-    def get_validated_mappings(cls, generated_dict: Dict[str, str]) -> Dict[str, str]:
+    def get_validated_mappings(cls, generated_dict: dict[str, str]) -> dict[str, str]:
         """Validates the input dictionary mapping within this class properties.
         Allows for extension on lower classes.
 
         Args:
-            generated_dict (Dict[str, str]): [description]
+            generated_dict (dict[str, str]): [description]
 
         Returns:
-            Dict[str, str]: Validated dictionary.
+            dict[str, str]: Validated dictionary.
         """
         return generated_dict
 
 
 class DSeriesRepeatedGroupsWithInlineMappedProperties(DSeriesRepeatedGroupedProperties):
     @classmethod
-    def get_inline_properties(cls, inline_properties: List[str]) -> Dict[str, str]:
+    def get_inline_properties(cls, inline_properties: list[str]) -> dict[str, str]:
         """Processes all unmapped properties and returns them in a dictionary.
         This method can be replaced in concrete implementations of this class.
         Follows a philosophy of FIFO for repeated keys.
         Args:
-            inline_properties (List[str]): List of property values which key was not found.
+            inline_properties (list[str]): List of property values which key was not found.
         Returns:
-            Dict[str, str]: Resulting inline mapped properties.
+            dict[str, str]: Resulting inline mapped properties.
         """
-        result_dict: Dict[str, str] = {}
+        result_dict: dict[str, str] = {}
         for unmapped in inline_properties:
             unformatted_key, value = get_line_property_key_value(
                 unmapped, reversed_key=False
@@ -903,15 +899,15 @@ class DSeriesTreeStructure(DSeriesStructure):
 
     @classmethod
     def parse_text_lines(
-        cls, text_lines: List[List[str]]
-    ) -> Tuple[DSeriesStructure, int]:
+        cls, text_lines: list[list[str]]
+    ) -> tuple[DSeriesStructure, int]:
         """Parses a list of strings into the properties of a structure.
         Example:
             [   ["1", "Property value"],
                 ["2", "Values in Property"],
                 ["4", "2"]]
         Args:
-            text_lines (List[List[str]]): List of properties as strings.
+            text_lines (list[list[str]]): List of properties as strings.
 
         Raises:
             ValueError: When the number of values for a property does not match its definition.
@@ -924,7 +920,7 @@ class DSeriesTreeStructure(DSeriesStructure):
 
         def get_list_values(
             struct_idx: int, field_name: str, text_lines: list
-        ) -> Tuple[DSeriesStructure, int]:
+        ) -> tuple[DSeriesStructure, int]:
             """Auxiliar method to either parse as a DSeriesStructure or as a list of
             any different object.
 
@@ -934,7 +930,7 @@ class DSeriesTreeStructure(DSeriesStructure):
                 text_lines (list): Lines containing values to parse.
 
             Returns:
-                Tuple[DSeriesStructure, int]: Parsed structure and lines read.
+                tuple[DSeriesStructure, int]: Parsed structure and lines read.
             """
             list_type = get_field_collection_type(cls, struct_idx)
             if issubclass(list_type, DSeriesTreeStructureCollection):
@@ -994,16 +990,16 @@ class DSeriesTreeStructure(DSeriesStructure):
 
     @classmethod
     def get_tree_structure_read_lines(
-        cls, parsed_tuple: Tuple[DSeriesStructure, int]
-    ) -> Tuple[DSeriesStructure, int]:
+        cls, parsed_tuple: tuple[DSeriesStructure, int]
+    ) -> tuple[DSeriesStructure, int]:
         """Allows inherited classes to override how many lines have been actually been read
         for a given parsed structure based on the cls being instantiated.
 
         Args:
-            parsed_tuple (Tuple[DSeriesStructure, int]): Tuple of parsed structure and read lines for it.
+            parsed_tuple (tuple[DSeriesStructure, int]): Tuple of parsed structure and read lines for it.
 
         Returns:
-            Tuple[DSeriesStructure, int]: Resulting tuple with real number of parsed lines.
+            tuple[DSeriesStructure, int]: Resulting tuple with real number of parsed lines.
         """
         return parsed_tuple
 
@@ -1056,8 +1052,8 @@ class DSeriesTreeStructurePropertiesInGroups(DSeriesTreeStructure):
 
     @classmethod
     def get_tree_structure_read_lines(
-        cls, parsed_tuple: Tuple[DSeriesStructure, int]
-    ) -> Tuple[DSeriesStructure, int]:
+        cls, parsed_tuple: tuple[DSeriesStructure, int]
+    ) -> tuple[DSeriesStructure, int]:
         # Only one line is meant to be read as parsed_text_lines is mapped 1:1 lines-properties.
         return parsed_tuple[0], 1
 
@@ -1093,12 +1089,12 @@ class DSeriesTreeStructureCollection(DSeriesStructure):
         return parsed_structure
 
     @classmethod
-    def get_number_of_structures(cls, lines: List[List[str]]) -> int:
+    def get_number_of_structures(cls, lines: list[list[str]]) -> int:
         """Provides an overridable method that retrieves the number of
         structures contained in the tree collection.
 
         Args:
-            lines (List[List[str]]): Tree collection lines.
+            lines (list[list[str]]): Tree collection lines.
 
         Returns:
             int: Number of structures expected.
@@ -1107,12 +1103,12 @@ class DSeriesTreeStructureCollection(DSeriesStructure):
 
     @classmethod
     def parse_collection_type(
-        cls, collecion_type: Type, lines: list
-    ) -> Tuple[DSeriesStructure, int]:
+        cls, collecion_type: type, lines: list
+    ) -> tuple[DSeriesStructure, int]:
         return collecion_type.parse_text_lines(lines)
 
     @classmethod
-    def parse_text_lines(cls, lines: List[str]) -> Tuple[DSeriesStructure, int]:
+    def parse_text_lines(cls, lines: list[str]) -> tuple[DSeriesStructure, int]:
         # Get class types
         collection_property_name = list(cls.model_fields.items())[0][0]
         structure_type = get_field_collection_type(cls, 0)
@@ -1143,8 +1139,8 @@ class DSeriesMatrixTreeStructureCollection(DSeriesTreeStructureCollection):
     # but not object creation.
     @classmethod
     def parse_collection_type(
-        cls, collecion_type: Type, lines: list
-    ) -> Tuple[DSeriesStructure, int]:
+        cls, collecion_type: type, lines: list
+    ) -> tuple[DSeriesStructure, int]:
         parsed_structure, _ = collecion_type.parse_text_lines(
             [[line] for line in lines[0]]
         )
@@ -1177,7 +1173,7 @@ class DSerieParser(BaseParser):
 
     @property
     @abstractmethod
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         raise NotImplementedError("Implement in derived classes.")
 
     def parse(self, filename: FilePath) -> DSeriesStructure:
@@ -1189,7 +1185,7 @@ class DSerieParser(BaseParser):
         return datastructure
 
     @staticmethod
-    def parse_group_as_dict(text_lines: str) -> Dict[str, str]:
+    def parse_group_as_dict(text_lines: str) -> dict[str, str]:
         """Parses a text with headers such as
         [GROUP] and [END OF GROUP] into a dict.
 
@@ -1218,9 +1214,9 @@ class DSerieParser(BaseParser):
     @staticmethod
     def parse_group(
         text_lines: str, loose_properties: bool = False, unique_keys: bool = False
-    ) -> Iterable[Tuple[str, str]]:
+    ) -> Iterable[tuple[str, str]]:
         """Parses a text with headers such as [GROUP] and [END OF GROUP] and
-        yields each property of the group as a Tuple[property name, value].
+        yields each property of the group as a tuple[property name, value].
         Because it is an iterable it may contain repeated elements.
         Delegating responsibility on what to do with such elements to the caller.
 
@@ -1246,10 +1242,10 @@ class DSerieParser(BaseParser):
             Exception: [description]
 
         Returns:
-            Iterable[Tuple[str, str]]: Parsed collection of property values, can include repe.
+            Iterable[tuple[str, str]]: Parsed collection of property values, can include repe.
 
         Yields:
-            Iterator[Iterable[Tuple[str, str]]]: Parsed Tuple[Property name, value]
+            Iterator[Iterable[tuple[str, str]]]: Parsed tuple[Property name, value]
         """
         currentkey = ""
         data = ""
@@ -1293,7 +1289,7 @@ class DSerieParser(BaseParser):
         text: str,
         exceptions=["vertical", "soil", "residual_settlements"],
         skipped_keys=[],
-    ) -> Dict[str, Union[List[str], str]]:
+    ) -> dict[str, list[str] | str]:
         """Method to parse several groups in a sli/sld file that can include repeated groups.
 
         Includes an exception to always parse a group as a list.
@@ -1352,7 +1348,7 @@ class DSerieParser(BaseParser):
 
                 # end of current group signaled with [END OF GROUP]
                 elif key == "end_of_" + currentkey:
-                    # If key already exists, this is a repeated group -> List
+                    # If key already exists, this is a repeated group -> list
                     if currentkey in parsed_dict:
                         # Append in case of a list (2+ elements)
                         if isinstance(parsed_dict[currentkey], list):
@@ -1405,14 +1401,14 @@ def strip_line_first_element(text: str):
     return split_line_elements(text)[0]
 
 
-def split_line_elements(text: str) -> List[str]:
+def split_line_elements(text: str) -> list[str]:
     """Separates by space and tabulator.
 
     Args:
         text (str): Text to break into separate fields.
 
     Returns:
-        List[str]: List of formatted values.
+        list[str]: List of formatted values.
     """
     # parts = re.split(" |\t", text.strip())
     parts = shlex.split(text.strip())
@@ -1444,7 +1440,7 @@ def get_line_property_value(text: str, reversed_key: bool) -> str:
     return value
 
 
-def get_line_property_key_value(text: str, reversed_key: bool) -> Tuple[str, str]:
+def get_line_property_key_value(text: str, reversed_key: bool) -> tuple[str, str]:
     """Returns the unformatted key and formatted value for a given line.
     Examples:
         reversed_key = False
@@ -1457,7 +1453,7 @@ def get_line_property_key_value(text: str, reversed_key: bool) -> Tuple[str, str
         reversed_key (bool): Whether the key comes before or after the value.
 
     Returns:
-        Tuple[str, str]: Unformatted key and formatted value.
+        tuple[str, str]: Unformatted key and formatted value.
     """
     key_idx, value_idx = (-1, 0) if reversed_key else (0, -1)
     text_parts = re.split(":|=", text.strip())
@@ -1472,19 +1468,19 @@ def get_line_property_key_value(text: str, reversed_key: bool) -> Tuple[str, str
     return key_part, ""
 
 
-def get_field_collection_type(class_type: Type, field_idx: int) -> Type:
+def get_field_collection_type(class_type: type, field_idx: int) -> type:
     """Gets the type wrapped by a collection of a given class.
     Example:
         DummyClass:
-            dummycollection: List[SubDummyClass]
+            dummycollection: list[SubDummyClass]
         get_field_collection_type(DummyClass, 0) -> SubDummyClass
 
     Args:
-        class_type (Type): Class containing a collection field.
+        class_type (type): Class containing a collection field.
         field_idx (int): Position of the collection field in the class.
 
     Returns:
-        Type: The class for the items in the collection.
+        type: The class for the items in the collection.
     """
     from typing import get_args
 
@@ -1494,26 +1490,26 @@ def get_field_collection_type(class_type: Type, field_idx: int) -> Type:
     return get_args(list_type.annotation)[0]
 
 
-def is_structure_collection(field: Type) -> bool:
+def is_structure_collection(field: type) -> bool:
     return inspect.isclass(field) and issubclass(field, DSeriesStructure)
 
 
 def read_property_as_list(
-    field_name: str, field: Type, text_lines: list
-) -> Tuple[List[DSeriesStructure], int]:
+    field_name: str, field: type, text_lines: list
+) -> tuple[list[DSeriesStructure], int]:
     """Reads a property containing a collection of values represented as
     a list of strings.
 
     Args:
         field_name (str): Name of the field to parse.
-        field (Type): Type to parse the values to.
+        field (type): type to parse the values to.
         text_lines (list): List of list of strings containing values.
 
     Raises:
         ValueError: If the values given don't match the defined expectations.
 
     Returns:
-        Tuple[List[DSeriesStructure], int]: Returns generated DSeriesStructures and lines read.
+        tuple[list[DSeriesStructure], int]: Returns generated DSeriesStructures and lines read.
     """
     # Assumes the values are separated by spaces.
     list_size = int(get_line_property_value(text_lines[0][0], reversed_key=True))

--- a/geolib/models/dsettlement/drains.py
+++ b/geolib/models/dsettlement/drains.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
-from typing import List, Optional, Union
 
 from geolib.models import BaseDataClass
 
@@ -11,7 +10,7 @@ from .internal import VerticalDrain as vd
 class ScheduleValues(BaseDataClass, metaclass=ABCMeta):
     """ScheduleValues to inherit from"""
 
-    schedule: Optional[DrainSchedule] = None
+    schedule: DrainSchedule | None = None
 
     @abstractmethod
     def _to_internal(self):
@@ -56,8 +55,8 @@ class ScheduleValuesSimpleInput(ScheduleValues):
     begin_time: float
     end_time: float
     underpressure: float
-    water_head_during_dewatering: Optional[float] = None
-    tube_pressure_during_dewatering: Optional[float] = None
+    water_head_during_dewatering: float | None = None
+    tube_pressure_during_dewatering: float | None = None
 
     def _to_internal(self, verticaldrains: vd) -> vd:
         verticaldrains.schedule_type = DrainSchedule.SIMPLE_INPUT
@@ -83,9 +82,9 @@ class ScheduleValuesDetailedInput(ScheduleValues):
         Water head -- The vertical level where the negative pore pressure equals the enforced underpressure during dewatering.
     """
 
-    time: List[timedelta] = []
-    underpressure: List[float] = []
-    water_level: List[float] = []
+    time: list[timedelta] = []
+    underpressure: list[float] = []
+    water_level: list[float] = []
 
     def _to_internal(self, verticaldrains: vd) -> vd:
         verticaldrains.schedule_type = DrainSchedule.DETAILED_INPUT
@@ -114,9 +113,9 @@ class VerticalDrain(BaseDataClass):
     range_to: float
     bottom_position: float
     center_to_center: float
-    width: Optional[float] = None
-    diameter: Optional[float] = None
-    thickness: Optional[float] = None
+    width: float | None = None
+    diameter: float | None = None
+    thickness: float | None = None
     grid: DrainGridType = DrainGridType.UNDERDETERMINED
     schedule: ScheduleValues = None
 

--- a/geolib/models/dsettlement/dsettlement_model.py
+++ b/geolib/models/dsettlement/dsettlement_model.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import timedelta
 from pathlib import Path
-from typing import Annotated, BinaryIO, List, Optional, Type, Union
+from typing import Annotated, BinaryIO
 
 from pydantic import FilePath, StringConstraints
 
@@ -58,12 +58,10 @@ class DSettlementModel(BaseModel):
     \*.sli files, read \*.sld and \*.err files.
     """
 
-    datastructure: Union[
-        DSettlementStructure, DSettlementOutputStructure
-    ] = DSettlementStructure()
+    datastructure: DSettlementStructure | DSettlementOutputStructure = DSettlementStructure()
 
     @property
-    def parser_provider_type(self) -> Type[DSettlementParserProvider]:
+    def parser_provider_type(self) -> type[DSettlementParserProvider]:
         return DSettlementParserProvider
 
     @property
@@ -75,10 +73,10 @@ class DSettlementModel(BaseModel):
         return self.get_meta_property("dsettlement_console_path")
 
     @property
-    def console_flags(self) -> List[str]:
+    def console_flags(self) -> list[str]:
         return [CONSOLE_RUN_BATCH_FLAG]
 
-    def serialize(self, filename: Union[FilePath, BinaryIO]):
+    def serialize(self, filename: FilePath | BinaryIO):
         """
         Serialize and pre-process
         Args:
@@ -302,7 +300,7 @@ class DSettlementModel(BaseModel):
     # To create multiple layers
     def add_boundary(
         self,
-        points: List[Point],
+        points: list[Point],
         use_probabilistic_defaults=True,
         stdv=0,
         distribution_boundaries=DistributionType.Undefined,
@@ -337,7 +335,7 @@ class DSettlementModel(BaseModel):
     def headlines(self):
         return self.datastructure.input_data.geometry_data.piezo_lines
 
-    def add_head_line(self, points: List[Point], is_phreatic=False) -> int:
+    def add_head_line(self, points: list[Point], is_phreatic=False) -> int:
         """Add head line to model."""
         # New points have to be created, whether points at the same location exist or not
         # This means that new points from geometry will re-use head line points,
@@ -405,9 +403,7 @@ class DSettlementModel(BaseModel):
         name: Annotated[str, StringConstraints(min_length=1, max_length=25)],
         time: timedelta,
         point: Point,
-        other_load: Union[
-            TrapeziformLoad, RectangularLoad, CircularLoad, TankLoad, UniformLoad
-        ],
+        other_load: TrapeziformLoad | RectangularLoad | CircularLoad | TankLoad | UniformLoad,
     ) -> None:
         internal_other_load = other_load._to_internal(time, point)
         if isinstance(self.other_loads, str):
@@ -423,11 +419,11 @@ class DSettlementModel(BaseModel):
     def add_non_uniform_load(
         self,
         name: Annotated[str, StringConstraints(min_length=1, max_length=25)],
-        points: List[Point],
+        points: list[Point],
         time_start: timedelta,
         gamma_dry: float,
         gamma_wet: float,
-        time_end: Optional[timedelta] = None,
+        time_end: timedelta | None = None,
     ):
         """Create non uniform load.
 
@@ -470,7 +466,7 @@ class DSettlementModel(BaseModel):
             name, time.days, phreatic_line_id, headlines
         )
 
-    def set_calculation_times(self, time_steps: List[timedelta]):
+    def set_calculation_times(self, time_steps: list[timedelta]):
         """(Re)set calculation time(s).
 
         Sets a list of calculation times, sorted from low to high with a minimum of 0.
@@ -487,7 +483,7 @@ class DSettlementModel(BaseModel):
         )
         self.datastructure.input_data.residual_times = residual_times
 
-    def set_verticals(self, locations: List[Point]) -> None:
+    def set_verticals(self, locations: list[Point]) -> None:
         """
         Set calculation verticals in geometry.
         X and Y coordinates should be defined for each vertical.

--- a/geolib/models/dsettlement/dsettlement_parserprovider.py
+++ b/geolib/models/dsettlement/dsettlement_parserprovider.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Type
-
 from pydantic import FilePath
 
 from geolib.models.dseries_parser import DSerieParser, DSeriesStructure
@@ -12,11 +10,11 @@ class DSettlementInputParser(DSerieParser):
     """DSettlement parser of input files."""
 
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".sli"]
 
     @property
-    def dserie_structure(self) -> Type[DSettlementStructure]:
+    def dserie_structure(self) -> type[DSettlementStructure]:
         return DSettlementStructure
 
 
@@ -24,11 +22,11 @@ class DSettlementOutputParser(DSerieParser):
     """DSettlement parser of input files."""
 
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".sld"]
 
     @property
-    def dserie_structure(self) -> Type[DSettlementOutputStructure]:
+    def dserie_structure(self) -> type[DSettlementOutputStructure]:
         return DSettlementOutputStructure
 
 
@@ -37,13 +35,13 @@ class DSettlementParserProvider(BaseParserProvider):
     __output_parsers = None
 
     @property
-    def input_parsers(self) -> Tuple[DSettlementInputParser]:
+    def input_parsers(self) -> tuple[DSettlementInputParser]:
         if not self.__input_parsers:
             self.__input_parsers = (DSettlementInputParser(),)
         return self.__input_parsers
 
     @property
-    def output_parsers(self) -> Tuple[DSettlementOutputParser]:
+    def output_parsers(self) -> tuple[DSettlementOutputParser]:
         if not self.__output_parsers:
             self.__output_parsers = (DSettlementOutputParser(),)
         return self.__output_parsers

--- a/geolib/models/dsettlement/dsettlement_structures.py
+++ b/geolib/models/dsettlement/dsettlement_structures.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, List
 
 from geolib.models.dseries_parser import (
     DSeriesRepeatedGroupedProperties,
@@ -77,7 +76,7 @@ class ComplexVerticalSubstructure(DSeriesStructure):
 
                 # duplicate group before end
                 elif currentkey == key:
-                    # If key already exists, this is a group -> List
+                    # If key already exists, this is a group -> list
                     if currentkey in parsed_dict:
                         parsed_dict[currentkey] = parsed_dict[currentkey] + [
                             "".join(data)
@@ -96,7 +95,7 @@ class ComplexVerticalSubstructure(DSeriesStructure):
                 # end of current group
                 elif key == "end_of_" + currentkey:
                     logger.debug(f"Found {key}")
-                    # If key already exists, this is a group -> List
+                    # If key already exists, this is a group -> list
                     if currentkey in parsed_dict:
                         parsed_dict[currentkey] = parsed_dict[currentkey] + [
                             "".join(data)
@@ -136,14 +135,14 @@ class DSerieRepeatedTableStructure(DSeriesRepeatedGroupedProperties):
         return group_key != "column_indication"
 
     @classmethod
-    def get_validated_mappings(cls, generated_dict: Dict[str, str]) -> Dict[str, str]:
+    def get_validated_mappings(cls, generated_dict: dict[str, str]) -> dict[str, str]:
         """Transforms the generated dict from the parent into our own mapping.
 
         Args:
-            generated_dict (Dict[str, str]): Parsed dictionary from parent.
+            generated_dict (dict[str, str]): Parsed dictionary from parent.
 
         Returns:
-            Dict[str, str]: Mapped dictionary with concrete properties.
+            dict[str, str]: Mapped dictionary with concrete properties.
         """
         class_name = cls.__name__.lower()
         n_groups = len(generated_dict.items())
@@ -154,7 +153,7 @@ class DSerieRepeatedTableStructure(DSeriesRepeatedGroupedProperties):
             for line in generated_dict.pop("column_indication").split("\n")
             if line != ""
         ]
-        parsed_dict: Dict[str, str] = {}
+        parsed_dict: dict[str, str] = {}
         # We assume there is only one 'repeated' key, so we get the values from it.
         for group_data in list(generated_dict.values())[0]:
             mapped_group = cls.get_mapped_group(columns, group_data)
@@ -169,18 +168,18 @@ class DSerieRepeatedTableStructure(DSeriesRepeatedGroupedProperties):
 
     @staticmethod
     def get_mapped_group(
-        column_list: List[str], group_line: str
-    ) -> Dict[str, List[Dict[str, str]]]:
+        column_list: list[str], group_line: str
+    ) -> dict[str, list[dict[str, str]]]:
         """Based on the input column and the group line, generates a list of
         dictionary entries which are mapped to the first element of the group
         line.
 
         Args:
-            column_list (List[str]): List of columns to map.
+            column_list (list[str]): List of columns to map.
             group_line (str): Content containing id of dictionary and list values.
 
         Returns:
-            Dict[str, List[Dict[str, str]]]: Generated mapped group.
+            dict[str, list[dict[str, str]]]: Generated mapped group.
         """
         lines = [
             split_line_elements(line) for line in group_line.split("\n") if line != ""

--- a/geolib/models/dsettlement/internal.py
+++ b/geolib/models/dsettlement/internal.py
@@ -3,7 +3,6 @@ from enum import Enum, IntEnum
 from inspect import cleandoc
 from math import isclose
 from operator import attrgetter
-from typing import Dict, List, Optional, Tuple, Type, Union
 
 from pydantic import Field, StringConstraints
 from pydantic.types import PositiveInt
@@ -67,7 +66,7 @@ class DSeriePoint(DSeriesTreeStructure):
     tolerance: float = TOLERANCE
 
     @classmethod
-    def get_structure_required_fields(cls) -> List[Tuple[str, Type]]:
+    def get_structure_required_fields(cls) -> list[tuple[str, type]]:
         point_required_field_names = [
             required_field[0] for required_field in get_required_class_field(cls)
         ]
@@ -92,7 +91,7 @@ class DSeriePoint(DSeriesTreeStructure):
 
 
 class SoilCollection(DSeriesStructureCollection):
-    soil: List[SoilInternal] = []
+    soil: list[SoilInternal] = []
 
     def add_soil_if_unique(self, soil, tolerance=TOLERANCE) -> None:
         for added_soil in self.soil:
@@ -110,7 +109,7 @@ class Version(DSerieVersion):
 class Points(DSeriesMatrixTreeStructureCollection):
     """Representation of [POINTS] group."""
 
-    points: List[DSeriePoint] = []
+    points: list[DSeriePoint] = []
 
     def add_point_if_unique(self, point: DSeriePoint, tolerance=TOLERANCE) -> DSeriePoint:
         if point in self.points:
@@ -136,7 +135,7 @@ class Curve(DSeriesTreeStructure):
     """Curve is a Line consisting of two points (by reference)."""
 
     id: PositiveInt = 1
-    points: Annotated[List[int], Field(min_length=2, max_length=2)]
+    points: Annotated[list[int], Field(min_length=2, max_length=2)]
 
     def __eq__(self, other: object) -> bool:
         """
@@ -157,7 +156,7 @@ class Curve(DSeriesTreeStructure):
 class Curves(DSeriesTreeStructureCollection):
     """Representation of [CURVES] group."""
 
-    curves: List[Curve] = []
+    curves: list[Curve] = []
 
     def create_curve(self, a: DSeriePoint, b: DSeriePoint):
         assert a.id != b.id
@@ -175,7 +174,7 @@ class Curves(DSeriesTreeStructureCollection):
 
         return curve
 
-    def create_curves(self, sorted_points: List[DSeriePoint]) -> List[Curve]:
+    def create_curves(self, sorted_points: list[DSeriePoint]) -> list[Curve]:
         new_curves = [
             self.create_curve(sorted_points[i], sorted_points[i + 1])
             for i in range(len(sorted_points) - 1)
@@ -191,7 +190,7 @@ class Curves(DSeriesTreeStructureCollection):
 
 class Boundary(DSeriesTreeStructure):
     id: Annotated[int, Field(ge=0)] = 0
-    curves: List[int] = []
+    curves: list[int] = []
 
     def __eq__(self, other: object) -> bool:
         """
@@ -212,9 +211,9 @@ class Boundary(DSeriesTreeStructure):
 class Boundaries(DSeriesTreeStructureCollection):
     """Representation of [BOUNDARIES] group."""
 
-    boundaries: List[Boundary] = []
+    boundaries: list[Boundary] = []
 
-    def create_boundary(self, curves: List[Curve]) -> Boundary:
+    def create_boundary(self, curves: list[Curve]) -> Boundary:
         boundary = Boundary(curves=[curve.id for curve in curves])
 
         # Return the id of existing one
@@ -268,7 +267,7 @@ class Layer(DSeriesTreeStructure):
 class Layers(DSeriesTreeStructureCollection):
     """Representation of [LAYERS] group."""
 
-    layers: List[Layer] = []
+    layers: list[Layer] = []
 
     def add_layer(self, layer: Layer):
         if layer in self.layers:
@@ -297,7 +296,7 @@ class Layers(DSeriesTreeStructureCollection):
 
 class PiezoLine(DSeriesTreeStructure):
     id: PositiveInt = 1
-    curves: List[int] = []
+    curves: list[int] = []
 
     def __eq__(self, other: object):
         if isinstance(other, PiezoLine):
@@ -308,9 +307,9 @@ class PiezoLine(DSeriesTreeStructure):
 class PiezoLines(DSeriesTreeStructureCollection):
     """Representation of [PIEZO LINES] group."""
 
-    piezolines: List[PiezoLine] = []
+    piezolines: list[PiezoLine] = []
 
-    def create_piezoline(self, curves: List[Curve]) -> PiezoLine:
+    def create_piezoline(self, curves: list[Curve]) -> PiezoLine:
         piezoline = PiezoLine(curves=[curve.id for curve in curves])
 
         if piezoline in self.piezolines:
@@ -333,7 +332,7 @@ class PiezoLines(DSeriesTreeStructureCollection):
 
 
 class UseProbabilisticDefaultsBoundaries(DSerieListStructure):
-    useprobabilisticdefaultsboundaries: List[Bool] = []
+    useprobabilisticdefaultsboundaries: list[Bool] = []
 
     def append_use_probabilistic_defaults_boundary(
         self, use_probabilistic_boundary: bool
@@ -344,14 +343,14 @@ class UseProbabilisticDefaultsBoundaries(DSerieListStructure):
 
 
 class StdvBoundaries(DSerieListStructure):
-    stdvboundaries: List[float] = []
+    stdvboundaries: list[float] = []
 
     def append_stdv_boundary(self, stdv_boundary: float):
         self.stdvboundaries.append(stdv_boundary)
 
 
 class DistributionBoundaries(DSerieListStructure):
-    distributionboundaries: List[DistributionType] = []
+    distributionboundaries: list[DistributionType] = []
 
     def append_distribution_boundary(self, distribution_boundary: DistributionType):
         if (distribution_boundary is DistributionType.Normal) or (
@@ -439,22 +438,22 @@ class GeometryData(DSeriesStructure):
         self.sort_boundaries()
         self.sort_probabilistic_list_based_on_new_indexes()
 
-    def create_list_of_indexes(self) -> List:
+    def create_list_of_indexes(self) -> list:
         return [boundary.id for boundary in self.boundaries.boundaries]
 
-    def sort_based_on_new_indexes(self, new_indexes: List, unsorted_list: List) -> List:
+    def sort_based_on_new_indexes(self, new_indexes: list, unsorted_list: list) -> list:
         return [unsorted_list[i] for i in new_indexes]
 
-    def get_point(self, point_id: int) -> Optional[DSeriePoint]:
+    def get_point(self, point_id: int) -> DSeriePoint | None:
         return self.points[point_id]
 
-    def get_curve(self, curve_id: int) -> Optional[Curve]:
+    def get_curve(self, curve_id: int) -> Curve | None:
         return self.curves[curve_id]
 
-    def get_boundary(self, boundary_id: int) -> Optional[Boundary]:
+    def get_boundary(self, boundary_id: int) -> Boundary | None:
         return self.boundaries[boundary_id]
 
-    def get_layer(self, layer_id: int) -> Optional[Layer]:
+    def get_layer(self, layer_id: int) -> Layer | None:
         return self.layers[layer_id]
 
 
@@ -476,13 +475,13 @@ class NonUniformLoad(BaseDataClass):
     gammawet: float = 10
     temporary: Bool = False
     endtime: int = 0
-    points: List[PointForLoad]
+    points: list[PointForLoad]
 
 
 class NonUniformLoads(DSeriesNoParseSubStructure):
     """Representation of [NON-UNIFORM LOADS] group."""
 
-    loads: Dict[
+    loads: dict[
         Annotated[str, StringConstraints(min_length=1, max_length=25)], NonUniformLoad
     ] = {}
 
@@ -490,7 +489,7 @@ class NonUniformLoads(DSeriesNoParseSubStructure):
         self,
         name: Annotated[str, StringConstraints(min_length=1, max_length=25)],
         load: NonUniformLoad,
-    ) -> Optional[ValueError]:
+    ) -> ValueError | None:
         if name in self.loads:
             raise ValueError(f"Load with name '{name}' already exists.")
         else:
@@ -503,16 +502,16 @@ class WaterLoad(BaseDataClass):
     name: str = ""
     time: int = 0
     phreatic_line: int = 1
-    headlines: List[List[int]] = [[]]
+    headlines: list[list[int]] = [[]]
 
 
 class WaterLoads(DSeriesNoParseSubStructure):
     """Representation of [WATER LOADS] group."""
 
-    waterloads: List[WaterLoad] = []
+    waterloads: list[WaterLoad] = []
 
     def add_waterload(
-        self, name: str, time: int, phreatic_line: int, headlines: List[List[int]]
+        self, name: str, time: int, phreatic_line: int, headlines: list[list[int]]
     ):
         self.waterloads.append(
             WaterLoad(
@@ -524,13 +523,13 @@ class WaterLoads(DSeriesNoParseSubStructure):
 class ResidualTimes(DSeriesNoParseSubStructure):
     """Representation of [RESIDUAL TIMES] group."""
 
-    time_steps: List[Annotated[int, Field(ge=0)]] = []
+    time_steps: list[Annotated[int, Field(ge=0)]] = []
 
 
 class Verticals(DSeriesNoParseSubStructure):
     """Representation of [VERTICALS] group."""
 
-    locations: List[DSeriePoint] = []
+    locations: list[DSeriePoint] = []
 
 
 class TypeOtherLoads(IntEnum):
@@ -591,17 +590,17 @@ class LoadValuesTank(BaseDataClass):
 class OtherLoad(BaseDataClass):
     load_type: TypeOtherLoads
     time: int = 0
-    load_values_trapeziform: Optional[LoadValuesTrapeziform] = None
-    load_values_circular: Optional[LoadValuesCircular] = None
-    load_values_rectangular: Optional[LoadValuesRectangular] = None
-    load_values_uniform: Optional[LoadValuesUniform] = None
-    load_values_tank: Optional[LoadValuesTank] = None
+    load_values_trapeziform: LoadValuesTrapeziform | None = None
+    load_values_circular: LoadValuesCircular | None = None
+    load_values_rectangular: LoadValuesRectangular | None = None
+    load_values_uniform: LoadValuesUniform | None = None
+    load_values_tank: LoadValuesTank | None = None
 
 
 class OtherLoads(DSeriesNoParseSubStructure):
     """Representation of [OTHER LOADS] group."""
 
-    loads: Dict[
+    loads: dict[
         Annotated[str, StringConstraints(min_length=1, max_length=25)], OtherLoad
     ] = {}
 
@@ -609,7 +608,7 @@ class OtherLoads(DSeriesNoParseSubStructure):
         self,
         name: Annotated[str, StringConstraints(min_length=1, max_length=25)],
         load: OtherLoad,
-    ) -> Optional[ValueError]:
+    ) -> ValueError | None:
         if name in self.loads:
             raise ValueError(f"Load with name '{name}' already exists.")
         else:
@@ -689,7 +688,7 @@ class CalculationOptions(DSeriesNoParseSubStructure):
         PreconPressureWithinLayer.CONSTANT_NO_CORRECTION
     )
     is_imaginary_surface: Bool = Bool.FALSE
-    imaginary_surface_layer: Optional[PositiveInt] = None
+    imaginary_surface_layer: PositiveInt | None = None
     is_submerging: Bool = Bool.FALSE
     use_end_time_for_fit: Bool = Bool.FALSE
     is_maintain_profile: Bool = Bool.FALSE
@@ -760,9 +759,9 @@ class VerticalDrain(DSeriesNoParseSubStructure):
     tube_pressure_during_dewatering: Annotated[
         float, Field(ge=-10000000.000, le=10000000.000)
     ] = 0  # relevant for the sand wall
-    time: List[Annotated[float, Field(ge=0, le=100000)]] = []
-    underpressure: List[Annotated[float, Field(ge=0, le=100000)]] = []
-    water_level: List[Annotated[float, Field(ge=-10000000.000, le=10000000.000)]] = []
+    time: list[Annotated[float, Field(ge=0, le=100000)]] = []
+    underpressure: list[Annotated[float, Field(ge=0, le=100000)]] = []
+    water_level: list[Annotated[float, Field(ge=-10000000.000, le=10000000.000)]] = []
 
 
 class InternalProbabilisticCalculationType(IntEnum):
@@ -837,23 +836,23 @@ class DSettlementInputStructure(DSeriesStructure):
     version: Version = Version()
     soil_collection: SoilCollection = SoilCollection()
     geometry_data: GeometryData = GeometryData()
-    geometry_1d_data: Optional[str] = None
+    geometry_1d_data: str | None = None
     run_identification: str = 2 * "\n"
     model: Model = Model()
-    verticals: Union[Verticals, str] = Verticals()
-    water: Union[float, str] = 9.81
-    non__uniform_loads: Union[NonUniformLoads, str] = NonUniformLoads()
-    water_loads: Union[WaterLoads, str] = WaterLoads()
-    other_loads: Union[OtherLoads, str] = OtherLoads()
-    calculation_options: Union[CalculationOptions, str] = CalculationOptions()
-    residual_times: Union[ResidualTimes, str] = ResidualTimes()
+    verticals: Verticals | str = Verticals()
+    water: float | str = 9.81
+    non__uniform_loads: NonUniformLoads | str = NonUniformLoads()
+    water_loads: WaterLoads | str = WaterLoads()
+    other_loads: OtherLoads | str = OtherLoads()
+    calculation_options: CalculationOptions | str = CalculationOptions()
+    residual_times: ResidualTimes | str = ResidualTimes()
     filter_band_width: str = cleandoc(
         """
         1 : Number of items
         0.05
         """
     )
-    vertical_drain: Union[VerticalDrain, str] = VerticalDrain()
+    vertical_drain: VerticalDrain | str = VerticalDrain()
     probabilistic_data: ProbabilisticData = ProbabilisticData()
     probabilistic_defaults: str = cleandoc(
         """
@@ -942,35 +941,35 @@ class DSettlementInputStructure(DSeriesStructure):
 
 
 class Stresses(DSeriesTableStructure):
-    stresses: List[Dict[str, float]]
+    stresses: list[dict[str, float]]
 
 
 class KoppejanSettlements(DSeriesTableStructure):
-    koppejansettlements: List[Dict[str, float]]
+    koppejansettlements: list[dict[str, float]]
 
 
 class Depths(DSerieListStructure):
-    depths: List[float]
+    depths: list[float]
 
 
 class Leakages(DSerieListStructure):
-    leakages: List[float]
+    leakages: list[float]
 
 
 class DrainedLayers(DSerieListStructure):
-    drainedlayers: List[int]
+    drainedlayers: list[int]
 
 
 class TimeSettlementPerLoad(DSerieMatrixStructure):
-    timesettlementperload: List[List[float]]
+    timesettlementperload: list[list[float]]
 
 
 class HorizontalDisplacements(DSerieMatrixStructure):
-    horizontaldisplacements: List[List[float]]
+    horizontaldisplacements: list[list[float]]
 
 
 class TimeDependentData(DSerieRepeatedTableStructure):
-    timedependentdata: Dict[float, List[Dict[str, float]]]
+    timedependentdata: dict[float, list[dict[str, float]]]
 
 
 class Vertical(ComplexVerticalSubstructure):
@@ -979,20 +978,20 @@ class Vertical(ComplexVerticalSubstructure):
     id: int
     x: float
     z: float
-    time__settlement_per_load: Optional[TimeSettlementPerLoad] = None
+    time__settlement_per_load: TimeSettlementPerLoad | None = None
     depths: Depths
-    leakages: Optional[Leakages] = None
-    drained_layers: Optional[DrainedLayers] = None
-    stresses: Optional[Stresses] = None
-    koppejan_settlement: Optional[KoppejanSettlements] = None
-    time__dependent_data: List[TimeDependentData]
-    elasticity: Optional[float] = None
-    horizontal_displacements: Optional[HorizontalDisplacements] = None
+    leakages: Leakages | None = None
+    drained_layers: DrainedLayers | None = None
+    stresses: Stresses | None = None
+    koppejan_settlement: KoppejanSettlements | None = None
+    time__dependent_data: list[TimeDependentData]
+    elasticity: float | None = None
+    horizontal_displacements: HorizontalDisplacements | None = None
 
 
 class ResidualSettlements(DSerieOldTableStructure):
-    # TODO LIst[Dict[str, float]] but can be empty which now gives a validation error
-    residualsettlements: List[Dict[str, float]]
+    # TODO LIst[dict[str, float]] but can be empty which now gives a validation error
+    residualsettlements: list[dict[str, float]]
 
 
 class CalculationSettings(DSeriesStructure):
@@ -1003,13 +1002,13 @@ class CalculationSettings(DSeriesStructure):
 class Results(DSeriesRepeatedGroupedProperties):
     """Representation of [results] group in sld file."""
 
-    calculation_settings: Optional[CalculationSettings] = None
+    calculation_settings: CalculationSettings | None = None
     verticals_count: int
-    vertical: List[Vertical]
-    residual_settlements: List[ResidualSettlements]
-    amounts_of_loads: Optional[str] = None
-    dissipation_in_layers: Optional[str] = None
-    reliability_calculation_results: Optional[str] = None
+    vertical: list[Vertical]
+    residual_settlements: list[ResidualSettlements]
+    amounts_of_loads: str | None = None
+    dissipation_in_layers: str | None = None
+    reliability_calculation_results: str | None = None
 
 
 class DSettlementOutputStructure(DSeriesStructure):
@@ -1022,4 +1021,4 @@ class DSettlementOutputStructure(DSeriesStructure):
 
 class DSettlementStructure(DSeriesStructure):
     input_data: DSettlementInputStructure = DSettlementInputStructure()
-    output_data: Optional[Results] = None
+    output_data: Results | None = None

--- a/geolib/models/dsettlement/internal_soil.py
+++ b/geolib/models/dsettlement/internal_soil.py
@@ -1,5 +1,4 @@
 from enum import Enum, IntEnum
-from typing import Optional
 
 from geolib.models.dseries_parser import DSeriesUnmappedNameProperties
 from geolib.models.internal import Bool

--- a/geolib/models/dsettlement/loads.py
+++ b/geolib/models/dsettlement/loads.py
@@ -1,6 +1,5 @@
 from abc import ABCMeta, abstractmethod
 from datetime import timedelta
-from typing import Optional
 
 from geolib.geometry import Point
 from geolib.models import BaseDataClass
@@ -19,7 +18,7 @@ from .internal import TypeOtherLoads
 class OtherLoad(BaseDataClass, metaclass=ABCMeta):
     """Other Load Class to inherit from."""
 
-    load_type: Optional[TypeOtherLoads] = None
+    load_type: TypeOtherLoads | None = None
 
     @abstractmethod
     def _to_internal(self, time: timedelta, p: Point):

--- a/geolib/models/dsheetpiling/calculation_options.py
+++ b/geolib/models/dsheetpiling/calculation_options.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta
-from typing import Optional, Union
 
 from pydantic import Field
 from typing_extensions import Annotated
@@ -31,13 +30,7 @@ class CalculationOptionsPerStage(BaseDataClass):
     """
 
     anchor_factor: float = 1
-    partial_factor_set: Optional[
-        Union[
-            PartialFactorSetEC7NADBE,
-            PartialFactorSetCUR,
-            PartialFactorSetEC7NADNL,
-        ]
-    ] = None
+    partial_factor_set: PartialFactorSetEC7NADBE | PartialFactorSetCUR | PartialFactorSetEC7NADNL | None = None
 
 
 class CalculationOptions(BaseDataClass, metaclass=ABCMeta):
@@ -62,14 +55,14 @@ class CalculationOptions(BaseDataClass, metaclass=ABCMeta):
     @property
     def calculation_properties(
         self,
-    ) -> Union[
-        "StandardCalculationOptions",
-        "DesignSheetpilingLengthCalculationOptions",
-        "VerifyCalculationOptions",
-        "KranzAnchorStrengthCalculationOptions",
-        "OverallStabilityCalculationOptions",
-        "ReliabilityAnalysisCalculationOptions",
-    ]:
+    ) -> (
+        "StandardCalculationOptions" |
+        "DesignSheetpilingLengthCalculationOptions" |
+        "VerifyCalculationOptions" |
+        "KranzAnchorStrengthCalculationOptions" |
+        "OverallStabilityCalculationOptions" |
+        "ReliabilityAnalysisCalculationOptions"
+    ):
         _calculation_properties_map = {
             CalculationType.STANDARD: StandardCalculationOptions,
             CalculationType.DESIGN_SHEETPILING_LENGTH: DesignSheetpilingLengthCalculationOptions,

--- a/geolib/models/dsheetpiling/constructions.py
+++ b/geolib/models/dsheetpiling/constructions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from geolib.models import BaseDataClass
 from geolib.models.dsheetpiling.internal import SheetPileElement
 from geolib.models.dsheetpiling.internal import VerticalBalance as InternalVerticalBalance
@@ -31,19 +29,17 @@ class PileProperties(BaseDataClass):
      reduction_factor_on_maximum_moment  : The reduction factor applied to the maximum allowable moment
     """
 
-    material_type: Optional[
-        SheetPilingElementMaterialType
-    ] = SheetPilingElementMaterialType.Steel
-    elastic_stiffness_ei: Optional[float] = None
-    diameter: Optional[float] = None
-    section_bottom_level: Optional[float] = None
-    reduction_factor_on_ei: Optional[float] = None
-    mr_char_el: Optional[float] = None
-    mr_char_pl: Optional[float] = None
-    modification_factor_k_mod: Optional[float] = None
-    material_factor_gamma_m: Optional[float] = None
-    reduction_factor_on_maximum_moment: Optional[float] = None
-    note_on_reduction_factor: Optional[str] = None
+    material_type: SheetPilingElementMaterialType | None = SheetPilingElementMaterialType.Steel
+    elastic_stiffness_ei: float | None = None
+    diameter: float | None = None
+    section_bottom_level: float | None = None
+    reduction_factor_on_ei: float | None = None
+    mr_char_el: float | None = None
+    mr_char_pl: float | None = None
+    modification_factor_k_mod: float | None = None
+    material_factor_gamma_m: float | None = None
+    reduction_factor_on_maximum_moment: float | None = None
+    note_on_reduction_factor: str | None = None
 
 
 class WoodenSheetPileProperties(BaseDataClass):
@@ -64,15 +60,15 @@ class WoodenSheetPileProperties(BaseDataClass):
 
     """
 
-    elasticity_modulus_e_m_0_mean: Optional[float] = None
-    charac_flexural_strength_f_m_0_char: Optional[float] = None
-    system_factor_k_sys: Optional[float] = None
-    deform_factor_k_def: Optional[float] = None
-    creep_factor_psi_2_eff: Optional[float] = None
-    material_factor_gamma_m: Optional[float] = None
-    modif_factor_on_f_m_0_char_short_term_k_mod_f_short: Optional[float] = None
-    modif_factor_on_f_m_0_char_long_term_k_mod_f_long: Optional[float] = None
-    modification_factor_on_e_m_0_d_k_mod_e: Optional[float] = None
+    elasticity_modulus_e_m_0_mean: float | None = None
+    charac_flexural_strength_f_m_0_char: float | None = None
+    system_factor_k_sys: float | None = None
+    deform_factor_k_def: float | None = None
+    creep_factor_psi_2_eff: float | None = None
+    material_factor_gamma_m: float | None = None
+    modif_factor_on_f_m_0_char_short_term_k_mod_f_short: float | None = None
+    modif_factor_on_f_m_0_char_long_term_k_mod_f_long: float | None = None
+    modification_factor_on_e_m_0_d_k_mod_e: float | None = None
 
 
 class SheetPileProperties(BaseDataClass):
@@ -110,25 +106,21 @@ class SheetPileProperties(BaseDataClass):
 
     """
 
-    material_type: Optional[
-        SheetPilingElementMaterialType
-    ] = SheetPilingElementMaterialType.Steel
-    elastic_stiffness_ei: Optional[float] = None
-    acting_width: Optional[float] = None
-    section_bottom_level: Optional[
-        float
-    ] = None  # TODO important parameter, shouldn't be default
-    height: Optional[int] = 400  # value is defined in mm
-    width_of_sheet_piles: Optional[float] = None
-    section_area: Optional[int] = None
-    elastic_section_modulus_w_el: Optional[int] = None
-    reduction_factor_on_ei: Optional[float] = None
-    note_on_reduction_factor: Optional[str] = None
-    mr_char_el: Optional[float] = None
-    mr_char_pl: Optional[float] = None
-    modification_factor_k_mod: Optional[float] = None
-    material_factor_gamma_m: Optional[float] = None
-    reduction_factor_on_maximum_moment: Optional[float] = None
+    material_type: SheetPilingElementMaterialType | None = SheetPilingElementMaterialType.Steel
+    elastic_stiffness_ei: float | None = None
+    acting_width: float | None = None
+    section_bottom_level: float | None = None  # TODO important parameter, shouldn't be default
+    height: int | None = 400  # value is defined in mm
+    width_of_sheet_piles: float | None = None
+    section_area: int | None = None
+    elastic_section_modulus_w_el: int | None = None
+    reduction_factor_on_ei: float | None = None
+    note_on_reduction_factor: str | None = None
+    mr_char_el: float | None = None
+    mr_char_pl: float | None = None
+    modification_factor_k_mod: float | None = None
+    material_factor_gamma_m: float | None = None
+    reduction_factor_on_maximum_moment: float | None = None
 
 
 class SheetPileModelPlasticCalculationProperties(BaseDataClass):
@@ -147,9 +139,9 @@ class SheetPileModelPlasticCalculationProperties(BaseDataClass):
         :align: center
     """
 
-    symmetrical: Optional[bool] = False
-    plastic_moment_positive: Optional[float] = None
-    plastic_moment_negative: Optional[float] = None
+    symmetrical: bool | None = False
+    plastic_moment_positive: float | None = None
+    plastic_moment_negative: float | None = None
 
 
 class FullPlasticCalculationProperties(BaseDataClass):
@@ -177,17 +169,17 @@ class FullPlasticCalculationProperties(BaseDataClass):
         :align: center
     """
 
-    symmetrical: Optional[bool] = False
-    eI_branch_2_positive: Optional[float] = None
-    eI_branch_2_negative: Optional[float] = None
-    moment_point_1_positive: Optional[float] = None
-    moment_point_1_negative: Optional[float] = None
-    plastic_moment_positive: Optional[float] = None
-    plastic_moment_negative: Optional[float] = None
-    eI_branch_3_positive: Optional[float] = None
-    moment_point_2_positive: Optional[float] = None
-    eI_branch_3_negative: Optional[float] = None
-    moment_point_2_negative: Optional[float] = None
+    symmetrical: bool | None = False
+    eI_branch_2_positive: float | None = None
+    eI_branch_2_negative: float | None = None
+    moment_point_1_positive: float | None = None
+    moment_point_1_negative: float | None = None
+    plastic_moment_positive: float | None = None
+    plastic_moment_negative: float | None = None
+    eI_branch_3_positive: float | None = None
+    moment_point_2_positive: float | None = None
+    eI_branch_3_negative: float | None = None
+    moment_point_2_negative: float | None = None
 
 
 class DiaphragmWallProperties(BaseDataClass):
@@ -223,19 +215,17 @@ class DiaphragmWallProperties(BaseDataClass):
 
     """
 
-    material_type: Optional[
-        SheetPilingElementMaterialType
-    ] = SheetPilingElementMaterialType.Steel
-    section_bottom_level: Optional[float] = None
-    elastic_stiffness_ei: Optional[float] = None
-    acting_width: Optional[float] = None
-    reduction_factor_on_ei: Optional[float] = None
-    note_on_reduction_factor: Optional[str] = None
-    mr_char_el: Optional[float] = None
-    mr_char_pl: Optional[float] = None
-    modification_factor_k_mod: Optional[float] = None
-    material_factor_gamma_m: Optional[float] = None
-    reduction_factor_on_maximum_moment: Optional[float] = None
+    material_type: SheetPilingElementMaterialType | None = SheetPilingElementMaterialType.Steel
+    section_bottom_level: float | None = None
+    elastic_stiffness_ei: float | None = None
+    acting_width: float | None = None
+    reduction_factor_on_ei: float | None = None
+    note_on_reduction_factor: str | None = None
+    mr_char_el: float | None = None
+    mr_char_pl: float | None = None
+    modification_factor_k_mod: float | None = None
+    material_factor_gamma_m: float | None = None
+    reduction_factor_on_maximum_moment: float | None = None
 
 
 class DiaphragmWall(BaseDataClass):
@@ -250,12 +240,8 @@ class DiaphragmWall(BaseDataClass):
     """
 
     name: str = ""
-    diaphragm_wall_properties: Optional[
-        DiaphragmWallProperties
-    ] = DiaphragmWallProperties()
-    plastic_properties: Optional[
-        FullPlasticCalculationProperties
-    ] = FullPlasticCalculationProperties()
+    diaphragm_wall_properties: DiaphragmWallProperties | None = DiaphragmWallProperties()
+    plastic_properties: FullPlasticCalculationProperties | None = FullPlasticCalculationProperties()
 
     def to_internal(self) -> SheetPileElement:
         return SheetPileElement(
@@ -296,13 +282,9 @@ class Sheet(BaseDataClass):
     """
 
     name: str = ""
-    sheet_pile_properties: Optional[SheetPileProperties] = SheetPileProperties()
-    plastic_properties: Optional[
-        SheetPileModelPlasticCalculationProperties
-    ] = SheetPileModelPlasticCalculationProperties()
-    wooden_sheet_pile_properties: Optional[
-        WoodenSheetPileProperties
-    ] = WoodenSheetPileProperties()
+    sheet_pile_properties: SheetPileProperties | None = SheetPileProperties()
+    plastic_properties: SheetPileModelPlasticCalculationProperties | None = SheetPileModelPlasticCalculationProperties()
+    wooden_sheet_pile_properties: WoodenSheetPileProperties | None = WoodenSheetPileProperties()
 
     def to_internal(self) -> SheetPileElement:
         return SheetPileElement(
@@ -348,10 +330,8 @@ class Pile(BaseDataClass):
     """
 
     name: str = ""
-    pile_properties: Optional[PileProperties] = PileProperties()
-    plastic_properties: Optional[
-        FullPlasticCalculationProperties
-    ] = FullPlasticCalculationProperties()
+    pile_properties: PileProperties | None = PileProperties()
+    plastic_properties: FullPlasticCalculationProperties | None = FullPlasticCalculationProperties()
 
     def to_internal(self) -> SheetPileElement:
         return SheetPileElement(
@@ -390,8 +370,8 @@ class VerticalBalance(BaseDataClass):
         xi_factor: Statistic factor related to the number of CPT's used for derivation of the maximum point resistance
     """
 
-    max_point_resistance: Optional[float] = None
-    xi_factor: Optional[float] = None
+    max_point_resistance: float | None = None
+    xi_factor: float | None = None
 
     def to_internal(self) -> InternalVerticalBalance:
         return InternalVerticalBalance(

--- a/geolib/models/dsheetpiling/dsheetpiling_model.py
+++ b/geolib/models/dsheetpiling/dsheetpiling_model.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from pathlib import Path
-from typing import BinaryIO, List, Optional, Type, Union
+from typing import BinaryIO
 
 from pydantic import FilePath, PositiveFloat
 
@@ -57,12 +57,12 @@ class BaseModelType(BaseDataClass, metaclass=ABCMeta):
 
 
 class SheetModelType(BaseModelType):
-    method: Optional[LateralEarthPressureMethod] = None
-    check_vertical_balance: Optional[bool] = None
-    verification: Optional[bool] = None
-    trildens_calculation: Optional[bool] = None
-    reliability_analysis: Optional[bool] = None
-    elastic_calculation: Optional[bool] = None
+    method: LateralEarthPressureMethod | None = None
+    check_vertical_balance: bool | None = None
+    verification: bool | None = None
+    trildens_calculation: bool | None = None
+    reliability_analysis: bool | None = None
+    elastic_calculation: bool | None = None
 
     @property
     def model(self) -> ModelType:
@@ -70,9 +70,9 @@ class SheetModelType(BaseModelType):
 
 
 class WoodenSheetPileModelType(BaseModelType):
-    method: Optional[LateralEarthPressureMethod] = None
-    check_vertical_balance: Optional[bool] = None
-    verification: Optional[bool] = None
+    method: LateralEarthPressureMethod | None = None
+    check_vertical_balance: bool | None = None
+    verification: bool | None = None
     elastic_calculation: bool = True
     wooden_sheetpiling: bool = True
 
@@ -82,8 +82,8 @@ class WoodenSheetPileModelType(BaseModelType):
 
 
 class SinglePileModelType(BaseModelType):
-    pile_load_option: Optional[SinglePileLoadOptions] = None
-    elastic_calculation: Optional[bool] = None
+    pile_load_option: SinglePileLoadOptions | None = None
+    elastic_calculation: bool | None = None
 
     @property
     def model(self) -> ModelType:
@@ -102,9 +102,9 @@ class SinglePileModelType(BaseModelType):
 
 
 class DiaphragmModelType(BaseModelType):
-    method: Optional[LateralEarthPressureMethod] = None
-    check_vertical_balance: Optional[bool] = None
-    verification: Optional[bool] = None
+    method: LateralEarthPressureMethod | None = None
+    check_vertical_balance: bool | None = None
+    verification: bool | None = None
     elastic_calculation: bool = False
     diepwand_calculation: bool = True
 
@@ -120,13 +120,11 @@ class DSheetPilingModel(BaseModel):
     This model can read, modify and create \*.shi files, read \*.shd and \*.err files.
     """
 
-    current_stage: Optional[int] = None  # Forces user to always set a stage.
-    datastructure: Union[
-        DSheetPilingStructure, DSheetPilingDumpStructure
-    ] = DSheetPilingStructure()
+    current_stage: int | None = None  # Forces user to always set a stage.
+    datastructure: DSheetPilingStructure | DSheetPilingDumpStructure = DSheetPilingStructure()
 
     @property
-    def parser_provider_type(self) -> Type[DSheetPilingParserProvider]:
+    def parser_provider_type(self) -> type[DSheetPilingParserProvider]:
         return DSheetPilingParserProvider
 
     @property
@@ -138,7 +136,7 @@ class DSheetPilingModel(BaseModel):
         return self.get_meta_property("dsheetpiling_console_path")
 
     @property
-    def console_flags(self) -> List[str]:
+    def console_flags(self) -> list[str]:
         return [CONSOLE_RUN_BATCH_FLAG]
 
     @property
@@ -146,10 +144,10 @@ class DSheetPilingModel(BaseModel):
         return self.datastructure.dumpfile.output_data
 
     @property
-    def model_type(self) -> Union[str, ModelType]:
+    def model_type(self) -> str | ModelType:
         return self.datastructure.input_data.model.model
 
-    def serialize(self, filename: Union[FilePath, BinaryIO]):
+    def serialize(self, filename: FilePath | BinaryIO):
         ds = self.datastructure.input_data.model_dump()
         ds.update(
             {
@@ -251,7 +249,7 @@ class DSheetPilingModel(BaseModel):
                 f"calculation_options_per_stage is not required for stage {stage_id}."
             )
 
-    def _get_default_stage_none_provided(self, stage_id: Optional[int]) -> int:
+    def _get_default_stage_none_provided(self, stage_id: int | None) -> int:
         stage_id = stage_id if stage_id is not None else self.current_stage
         if stage_id is None:
             raise ValueError("No stages available yet: add a stage first.")
@@ -376,7 +374,7 @@ class DSheetPilingModel(BaseModel):
         )
 
     def set_construction(
-        self, top_level: float, elements: List[Union[Sheet, DiaphragmWall, Pile]]
+        self, top_level: float, elements: list[Sheet | DiaphragmWall | Pile]
     ) -> None:
         """Sets construction for the DSheetPilingModel.
 
@@ -405,13 +403,7 @@ class DSheetPilingModel(BaseModel):
 
     def add_load(
         self,
-        load: Union[
-            Moment,
-            HorizontalLineLoad,
-            NormalForce,
-            SoilDisplacement,
-            UniformLoad,
-        ],
+        load: Moment | HorizontalLineLoad | NormalForce | SoilDisplacement | UniformLoad,
         stage_id: int,
     ):
         """Adds other loads of type Moment, HorizontalLineLoad, NormalForce, SoilDisplacement or UniformLoad
@@ -447,7 +439,7 @@ class DSheetPilingModel(BaseModel):
 
     def add_anchor_or_strut(
         self,
-        support: Union[Anchor, Strut],
+        support: Anchor | Strut,
         stage_id: int,
         pre_stress: PositiveFloat = 0,
     ) -> None:
@@ -483,7 +475,7 @@ class DSheetPilingModel(BaseModel):
 
     def add_support(
         self,
-        support: Union[SpringSupport, RigidSupport],
+        support: SpringSupport | RigidSupport,
         stage_id: int,
     ) -> None:
         """Add spring or rigid support to a stage.

--- a/geolib/models/dsheetpiling/dsheetpiling_parserprovider.py
+++ b/geolib/models/dsheetpiling/dsheetpiling_parserprovider.py
@@ -1,5 +1,3 @@
-from typing import List, Tuple, Type
-
 from pydantic import FilePath
 
 from geolib.models.dseries_parser import DSerieParser, DSeriesStructure
@@ -12,11 +10,11 @@ class DSheetPilingInputParser(DSerieParser):
     """DSheetPiling parser of input files."""
 
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".shi"]
 
     @property
-    def dserie_structure(self) -> Type[DSheetPilingStructure]:
+    def dserie_structure(self) -> type[DSheetPilingStructure]:
         return DSheetPilingStructure
 
 
@@ -24,11 +22,11 @@ class DSheetPilingOutputParser(DSerieParser):
     """DSheetPiling parser of input files."""
 
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".shd"]
 
     @property
-    def dserie_structure(self) -> Type[DSheetPilingDumpStructure]:
+    def dserie_structure(self) -> type[DSheetPilingDumpStructure]:
         return DSheetPilingDumpStructure
 
 
@@ -37,13 +35,13 @@ class DSheetPilingParserProvider(BaseParserProvider):
     __output_parsers = None
 
     @property
-    def input_parsers(self) -> Tuple[DSheetPilingInputParser]:
+    def input_parsers(self) -> tuple[DSheetPilingInputParser]:
         if not self.__input_parsers:
             self.__input_parsers = (DSheetPilingInputParser(),)
         return self.__input_parsers
 
     @property
-    def output_parsers(self) -> Tuple[DSheetPilingOutputParser]:
+    def output_parsers(self) -> tuple[DSheetPilingOutputParser]:
         if not self.__output_parsers:
             self.__output_parsers = (DSheetPilingOutputParser(),)
         return self.__output_parsers

--- a/geolib/models/dsheetpiling/dsheetpiling_structures.py
+++ b/geolib/models/dsheetpiling/dsheetpiling_structures.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import Any, Dict, List, Tuple, get_type_hints
+from typing import get_type_hints
 
 from geolib.errors import ParserError
 from geolib.models.dseries_parser import (
@@ -49,13 +49,13 @@ class DSeriesPilingParserStructure(DSeriesStructure):
 
 class DSheetpilingSurchargeLoad(DSeriesRepeatedGroupsWithInlineMappedProperties):
     @classmethod
-    def get_list_field_names(cls) -> List[str]:
+    def get_list_field_names(cls) -> list[str]:
         super_field_names = super().get_list_field_names()
         super_field_names.append("point")
         return super_field_names
 
     @classmethod
-    def get_validated_mappings(cls, generated_dict: Dict[str, str]) -> Dict[str, str]:
+    def get_validated_mappings(cls, generated_dict: dict[str, str]) -> dict[str, str]:
         name_field = generated_dict.pop("", "")
         # Verify the name field has not been replaced by "surcharge_load"
         if "surcharge_load" in generated_dict:

--- a/geolib/models/dsheetpiling/internal.py
+++ b/geolib/models/dsheetpiling/internal.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from inspect import cleandoc
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any
 
 from pydantic import Field, StringConstraints
 from typing_extensions import Annotated
@@ -175,10 +175,10 @@ class Soil(DSeriesUnmappedNameProperties):
 
 
 class SoilCollection(DSeriesStructureCollection):
-    soil: List[Soil] = []
+    soil: list[Soil] = []
 
     @property
-    def soil_names(self) -> Set[str]:
+    def soil_names(self) -> set[str]:
         return {soil.name for soil in self.soil}
 
     def add_soil_if_unique(self, soil) -> None:
@@ -213,22 +213,22 @@ class SoilLayer(DSeriesNoParseSubStructure):
 
 class SoilProfile(DSeriesNoParseSubStructure):
     name: Annotated[str, StringConstraints(min_length=1, max_length=25)]
-    layers: List[SoilLayer]
+    layers: list[SoilLayer]
     coordinate: Point
 
 
 class SoilProfiles(DSeriesNoParseSubStructure):
-    soil_profiles: List[SoilProfile] = []
+    soil_profiles: list[SoilProfile] = []
     curve_number: Annotated[int, Field(ge=1, le=4)] = 3
     use_unloading_reloading_curve: bool = False
     modulus_reaction_type: int = ModulusReactionType.SECANT.value
 
     @property
-    def soil_profile_names(self) -> Set[str]:
+    def soil_profile_names(self) -> set[str]:
         return {soil_profile.name for soil_profile in self.soil_profiles}
 
     @property
-    def referenced_soil_names(self) -> Set[str]:
+    def referenced_soil_names(self) -> set[str]:
         return {layer.soil for profile in self.soil_profiles for layer in profile.layers}
 
 
@@ -431,7 +431,7 @@ class SheetPileElement(DSeriesUnmappedNameProperties):
 
 
 class SheetPiling(DSeriesStructureCollection):
-    sheetpiling: Annotated[List[SheetPileElement], Field(min_length=1)] = [
+    sheetpiling: Annotated[list[SheetPileElement], Field(min_length=1)] = [
         SheetPileElement()
     ]
     leveltopsheetpiling: Annotated[float, Field(ge=-10000, le=10000)] = 0.0
@@ -439,29 +439,29 @@ class SheetPiling(DSeriesStructureCollection):
 
 
 class VerticalBalance(DSeriesInlineMappedProperties):
-    sheetpilingqcrep: Optional[Annotated[float, Field(ge=0)]] = 0.001
-    sheetpilingxi: Optional[Annotated[float, Field(ge=0.1)]] = 1.39
+    sheetpilingqcrep: Annotated[float, Field(ge=0)] = 0.001
+    sheetpilingxi: Annotated[float, Field(ge=0.1)] = 1.39
 
 
 class Anchor(DSheetpilingTableEntry):
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
     level: float = 0
     e_modulus: Annotated[float, Field(gt=0)] = 2.1e8
-    cross_section: Optional[Annotated[float, Field(gt=0)]] = 1e-3
-    wall_height_kranz: Optional[Annotated[float, Field(ge=0)]] = 0.00
-    length: Optional[Annotated[float, Field(gt=0)]] = 1
-    angle: Optional[float] = 0.00
-    yield_force: Optional[Annotated[float, Field(ge=0)]] = 0.00
+    cross_section: Annotated[float, Field(gt=0)] = 1e-3
+    wall_height_kranz: Annotated[float, Field(ge=0)] = 0.00
+    length: Annotated[float, Field(gt=0)] = 1
+    angle: float | None = 0.00
+    yield_force: Annotated[float, Field(ge=0)] = 0.00
     side: Side = Side.RIGHT
 
 
 class Anchors(DSheetpilingUnwrappedTable):
     """Container for Anchor."""
 
-    anchors: List[Anchor] = []
+    anchors: list[Anchor] = []
 
     @property
-    def anchor_names(self) -> Set[str]:
+    def anchor_names(self) -> set[str]:
         return {anchor.name for anchor in self.anchors}
 
 
@@ -477,20 +477,20 @@ class Strut(DSheetpilingTableEntry):
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
     level: float = 0
     e_modulus: Annotated[float, Field(gt=0)] = 2.1e8
-    cross_section: Optional[Annotated[float, Field(gt=0)]] = 1e-4
-    length: Optional[Annotated[float, Field(gt=0)]] = 1
-    angle: Optional[float] = 0.00
-    buckling_force: Optional[Annotated[float, Field(ge=0)]] = 0.00
+    cross_section: Annotated[float, Field(gt=0)] = 1e-4
+    length: Annotated[float, Field(gt=0)] = 1
+    angle: float | None = 0.00
+    buckling_force: Annotated[float, Field(ge=0)] = 0.00
     side: Side = Side.RIGHT
 
 
 class Struts(DSheetpilingUnwrappedTable):
     """Container for Strut."""
 
-    struts: List[Strut] = []
+    struts: list[Strut] = []
 
     @property
-    def strut_names(self) -> Set[str]:
+    def strut_names(self) -> set[str]:
         return {strut.name for strut in self.struts}
 
 
@@ -508,25 +508,25 @@ class ConstructionStage(DSeriesUnmappedNameProperties):
     water_level_right: str = _DEFAULT_WATER_LEVEL_NAME
     surface_left: str = _DEFAULT_SURFACE_NAME
     surface_right: str = _DEFAULT_SURFACE_NAME
-    soil_profile_left: Optional[str] = _DEFAULT_SOIL_PROFILE_NAME
-    soil_profile_right: Optional[str] = _DEFAULT_SOIL_PROFILE_NAME
-    anchors: List[AnchorOrStrutPresstressReference] = []
-    struts: List[AnchorOrStrutPresstressReference] = []
-    spring_supports: List[str] = []
-    rigid_supports: List[str] = []
-    uniform_loads: List[str] = []
-    surcharge_loads_left: List[str] = []
-    surcharge_loads_right: List[str] = []
-    horizontal_line_loads: List[str] = []
-    moment_loads: List[str] = []
-    normal_forces: List[str] = []
+    soil_profile_left: str | None = _DEFAULT_SOIL_PROFILE_NAME
+    soil_profile_right: str | None = _DEFAULT_SOIL_PROFILE_NAME
+    anchors: list[AnchorOrStrutPresstressReference] = []
+    struts: list[AnchorOrStrutPresstressReference] = []
+    spring_supports: list[str] = []
+    rigid_supports: list[str] = []
+    uniform_loads: list[str] = []
+    surcharge_loads_left: list[str] = []
+    surcharge_loads_right: list[str] = []
+    horizontal_line_loads: list[str] = []
+    moment_loads: list[str] = []
+    normal_forces: list[str] = []
 
 
 class ConstructionStages(DSeriesStructureCollection):
-    stages: List[ConstructionStage] = []
+    stages: list[ConstructionStage] = []
 
     @property
-    def stage_names(self) -> Set[str]:
+    def stage_names(self) -> set[str]:
         return {stage.name for stage in self.stages}
 
 
@@ -538,10 +538,10 @@ class WaterLevel(DSeriesNoParseSubStructure):
 
 
 class WaterLevels(DSeriesNoParseSubStructure):
-    levels: List[WaterLevel] = []
+    levels: list[WaterLevel] = []
 
     @property
-    def water_level_names(self) -> Set[str]:
+    def water_level_names(self) -> set[str]:
         return {water_level.name for water_level in self.levels}
 
 
@@ -561,7 +561,7 @@ class StageOptions(DSeriesInlineMappedProperties):
 class CalculationOptionsPerStage(DSeriesStructureCollection):
     """Representation of [CALCULATION OPTIONS PER STAGE] block."""
 
-    stageoptions: List[StageOptions] = []
+    stageoptions: list[StageOptions] = []
 
 
 class UniformLoad(DSeriesUnmappedNameProperties):
@@ -579,10 +579,10 @@ class UniformLoad(DSeriesUnmappedNameProperties):
 
 
 class UniformLoads(DSeriesStructureCollection):
-    loads: List[UniformLoad] = []
+    loads: list[UniformLoad] = []
 
     @property
-    def load_names(self) -> Set[str]:
+    def load_names(self) -> set[str]:
         return {load.name for load in self.loads}
 
 
@@ -593,7 +593,7 @@ class SurchargePoint(DSeriesInlineMappedProperties):
 
 class SurchargeLoad(DSheetpilingSurchargeLoad):
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
-    points: List[SurchargePoint] = []
+    points: list[SurchargePoint] = []
     surchargeloadpermanent: LoadTypePermanentVariable = (
         LoadTypePermanentVariable.PERMANENT
     )
@@ -605,26 +605,26 @@ class SurchargeLoad(DSheetpilingSurchargeLoad):
 
 
 class SurchargeLoads(DSeriesStructureCollection):
-    loads: List[SurchargeLoad] = []
+    loads: list[SurchargeLoad] = []
 
     @property
-    def load_names(self) -> Set[str]:
+    def load_names(self) -> set[str]:
         return {load.name for load in self.loads}
 
 
 class Surface(DSeriesNoParseSubStructure):  # TODO determine structure
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
-    points: Annotated[List[Point], Field(min_length=1)]
-    points: Annotated[List[dict], Field(min_length=1)]
+    points: Annotated[list[Point], Field(min_length=1)]
+    points: Annotated[list[dict], Field(min_length=1)]
     distribution_type: DistributionType = DistributionType.NONE
     std: Annotated[float, Field(ge=0.0)] = 0.0
 
 
 class Surfaces(DSeriesNoParseSubStructure):  # TODO GroupList should be suitable?
-    surfaces: List[Surface] = []
+    surfaces: list[Surface] = []
 
     @property
-    def surface_names(self) -> Set[str]:
+    def surface_names(self) -> set[str]:
         return {surface.name for surface in self.surfaces}
 
 
@@ -639,7 +639,7 @@ class HorizontalLineLoad(DSeriesNoParseSubStructure):
 
 
 class HorizontalLineLoads(DSeriesNoParseSubStructure):
-    loads: List[HorizontalLineLoad] = []
+    loads: list[HorizontalLineLoad] = []
 
 
 class Moment(DSeriesNoParseSubStructure):
@@ -653,7 +653,7 @@ class Moment(DSeriesNoParseSubStructure):
 
 
 class Moments(DSeriesNoParseSubStructure):
-    loads: List[Moment] = []
+    loads: list[Moment] = []
 
 
 class NormalForce(DSeriesNoParseSubStructure):
@@ -669,7 +669,7 @@ class NormalForce(DSeriesNoParseSubStructure):
 
 
 class NormalForces(DSeriesNoParseSubStructure):
-    loads: List[NormalForce] = []
+    loads: list[NormalForce] = []
 
 
 class Support(DSeriesNoParseSubStructure):
@@ -682,10 +682,10 @@ class Support(DSeriesNoParseSubStructure):
 
 
 class SupportContainer(DSeriesNoParseSubStructure):
-    supports: List[Support] = []
+    supports: list[Support] = []
 
     @property
-    def support_names(self) -> Set[str]:
+    def support_names(self) -> set[str]:
         return {support.name for support in self.supports}
 
 
@@ -695,7 +695,7 @@ class VibrationPosition(DSeriesNoParseSubStructure):
 
 
 class VibrationPositions(DSeriesNoParseSubStructure):
-    positions: List[VibrationPosition] = []
+    positions: list[VibrationPosition] = []
 
 
 class Water(DSeriesUnmappedNameProperties):
@@ -715,7 +715,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
         Count=0
         """
     )
-    sheet_piling: Union[str, SheetPiling] = SheetPiling()
+    sheet_piling: str | SheetPiling = SheetPiling()
     combined_wall: str = ""
     vertical_balance: VerticalBalance = VerticalBalance()
     settlement_by_vibration_params: str = cleandoc(
@@ -723,16 +723,16 @@ class DSheetPilingInputStructure(DSeriesStructure):
         SheetPilingNumberOfPilesDrilled=2
         """
     )
-    horizontal_line_loads: Union[HorizontalLineLoads, str, None] = None
-    uniform_loads: Optional[UniformLoads] = None
-    surcharge_loads: Optional[SurchargeLoads] = None
+    horizontal_line_loads: HorizontalLineLoads | str | None = None
+    uniform_loads: UniformLoads | None = None
+    surcharge_loads: SurchargeLoads | None = None
     water: str = ""
     earth_quake: str = cleandoc(
         """
         0.00
         """
     )
-    soil_profiles: Union[SoilProfiles, str] = cleandoc(
+    soil_profiles: SoilProfiles | str = cleandoc(
         f"""
           1 Number of spring characteristics curves
           0 1/0 : Yes/No Unloading curve
@@ -749,7 +749,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
 
         """
     )
-    surfaces: Union[str, Surfaces] = cleandoc(
+    surfaces: str | Surfaces = cleandoc(
         f"""
         1 Number of surfaces 
         1     1 {_DEFAULT_SURFACE_NAME}
@@ -760,7 +760,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
         """
     )
     water: Water = Water()
-    waterlevels: Union[WaterLevels, str] = cleandoc(
+    waterlevels: WaterLevels | str = cleandoc(
         f"""
           1 Number of Waterlevels 
           3 Number of Data per Waterlevel 
@@ -771,7 +771,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
 
         """
     )
-    construction_stages: Union[str, ConstructionStages] = ConstructionStages()
+    construction_stages: str | ConstructionStages = ConstructionStages()
     calculation_options_per_stage: CalculationOptionsPerStage = (
         CalculationOptionsPerStage()
     )
@@ -799,14 +799,14 @@ class DSheetPilingInputStructure(DSeriesStructure):
     When there are no anchors, struts, supports, vibration positions or soil displacements in the model,
     their respective block is not present in the .shi file.
     """
-    soil_displacements: Optional[str] = None
-    rigid_supports: Union[str, SupportContainer, None] = None
-    spring_supports: Union[str, SupportContainer, None] = None
-    moments: Union[str, Moments, None] = None
-    normal_forces: Union[str, NormalForces, None] = None
-    anchors: Union[str, Anchors, None] = None
-    struts: Union[str, Struts, None] = None
-    vibration_positions: Union[str, VibrationPositions, None] = None
+    soil_displacements: str | None = None
+    rigid_supports: str | SupportContainer | None = None
+    spring_supports: str | SupportContainer | None = None
+    moments: str | Moments | None = None
+    normal_forces: str | NormalForces | None = None
+    anchors: str | Anchors | None = None
+    struts: str | Struts | None = None
+    vibration_positions: str | VibrationPositions | None = None
 
     # Custom validator
     _validate_run_identification = make_newline_validator(
@@ -894,7 +894,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
         passive_side: PassiveSide,
         method_left: LateralEarthPressureMethodStage,
         method_right: LateralEarthPressureMethodStage,
-        pile_top_displacement: Optional[float],
+        pile_top_displacement: float | None,
     ) -> None:
         if isinstance(self.construction_stages, str):
             self.construction_stages = ConstructionStages()
@@ -923,7 +923,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
         self.calculation_options_per_stage.stageoptions.append(StageOptions())
 
     def _get_validated_lateral_earth_pressure_method(
-        self, stage_method: Optional[LateralEarthPressureMethodStage]
+        self, stage_method: LateralEarthPressureMethodStage | None
     ) -> LateralEarthPressureMethodStage:
         """When no stage_method is provided, returns the method set in the
         model options.
@@ -963,11 +963,11 @@ class DSheetPilingInputStructure(DSeriesStructure):
                     f"For the Single Pile Model the left and right method must be the same. Received: left {method_left} and right {method_right}"
                 )
 
-    def _filter_none_values_from_key_value_dict(self, dict_: Dict) -> Dict:
+    def _filter_none_values_from_key_value_dict(self, dict_: dict) -> dict:
         # This way defaults can be defined only in the internal.
         return {k: v for k, v in dict_.items() if v is not None}
 
-    def _from_snake_to_pascal_case(self, dict_: Dict) -> Dict:
+    def _from_snake_to_pascal_case(self, dict_: dict) -> dict:
         return {k.replace("_", ""): v for k, v in dict_.items()}
 
     def add_water_level(self, stage_id: int, water_level: WaterLevel, side: Side) -> None:
@@ -1031,7 +1031,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
             raise ValueError(f"Provide a Side, received {side}")
 
     def set_construction(
-        self, top_level: float, elements: List[SheetPileElement]
+        self, top_level: float, elements: list[SheetPileElement]
     ) -> None:
         elements.sort(key=lambda element: element.sheetpilingelementlevel, reverse=True)
         for sheet in elements:
@@ -1050,7 +1050,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
     def add_element_in_sheet_piling(
         self,
         sheet: Any,
-        location_top: Optional[Point] = None,
+        location_top: Point | None = None,
     ) -> None:
         self.sheet_piling.update_level_top_sheet_pile(location_top)
         try:
@@ -1089,7 +1089,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
         )
 
     def add_load(
-        self, load: Union[HorizontalLineLoad, Moment, NormalForce], stage_id: int
+        self, load: HorizontalLineLoad | Moment | NormalForce, stage_id: int
     ):
         if isinstance(load, HorizontalLineLoad):
             self.is_valid_unique_load_names(
@@ -1171,7 +1171,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
         else:
             raise ValueError(f"Provide a Side, received {side}")
 
-    def is_valid_unique_load_names(self, load_list: List[str], name: str) -> bool:
+    def is_valid_unique_load_names(self, load_list: list[str], name: str) -> bool:
         """Load list should have unique names in list of loads."""
         if name in load_list:
             raise ValueError(
@@ -1197,7 +1197,7 @@ class DSheetPilingInputStructure(DSeriesStructure):
 
 
 class Resume(DSheetpilingWithNumberOfRowsTable):
-    resume: List[Dict[str, float]]
+    resume: list[dict[str, float]]
 
 
 class BreukData(DSeriesInlineReversedProperties):
@@ -1222,84 +1222,84 @@ class BreukData(DSeriesInlineReversedProperties):
 
 
 class MomentsForcesDisplacements(DSeriesWrappedTableStructure):
-    momentsforcesdisplacements: List[Dict[str, float]]
+    momentsforcesdisplacements: list[dict[str, float]]
 
 
 class AnchorData(DSheetpilingWithNumberOfRowsTable):
-    anchordata: List[Dict[str, Union[float, str]]]
+    anchordata: list[dict[str, float | str]]
 
 
 class Pressures(DSheetpilingWithNumberOfRowsTable):
-    pressures: List[Dict[str, Union[float, str]]]
+    pressures: list[dict[str, float | str]]
 
 
 class SideOutput(DSeriesStructure):
-    calculation_method: Optional[str] = None
-    water_level: Optional[str] = None
-    surface: Optional[str] = None
-    soil_profile_for_single_pile_model: Optional[str] = None
-    soil_profile_for_sheet_piling_model: Optional[str] = None
-    pressures: Optional[Pressures] = None
-    force_from_layer: Optional[str] = None
-    lambdas: Optional[str] = None
-    slide_plane: Optional[str] = None
-    vertical_balance_per_layer: Optional[str] = None
+    calculation_method: str | None = None
+    water_level: str | None = None
+    surface: str | None = None
+    soil_profile_for_single_pile_model: str | None = None
+    soil_profile_for_sheet_piling_model: str | None = None
+    pressures: Pressures | None = None
+    force_from_layer: str | None = None
+    lambdas: str | None = None
+    slide_plane: str | None = None
+    vertical_balance_per_layer: str | None = None
 
 
 class OutputConstructionStage(DSeriesRepeatedGroupedProperties):
-    anchor_data: Optional[AnchorData] = None
-    hload_data: Optional[str] = None
-    breuk_data: Optional[BreukData] = None
-    passive_side_data: Optional[str] = None
-    soil_collapse_data: Optional[str] = None
-    moments_forces_displacements: Optional[MomentsForcesDisplacements] = None
-    side: Optional[List[SideOutput]] = None
-    uniform_load_data: Optional[str] = None
-    horizontal_line_load_data: Optional[str] = None
-    surcharge_data: Optional[str] = None
-    normal_force_data: Optional[str] = None
-    moment_data: Optional[str] = None
-    support_data: Optional[str] = None
-    vertical_balance_data: Optional[str] = None
+    anchor_data: AnchorData | None = None
+    hload_data: str | None = None
+    breuk_data: BreukData | None = None
+    passive_side_data: str | None = None
+    soil_collapse_data: str | None = None
+    moments_forces_displacements: MomentsForcesDisplacements | None = None
+    side: list[SideOutput] | None = None
+    uniform_load_data: str | None = None
+    horizontal_line_load_data: str | None = None
+    surcharge_data: str | None = None
+    normal_force_data: str | None = None
+    moment_data: str | None = None
+    support_data: str | None = None
+    vertical_balance_data: str | None = None
 
     @classmethod
-    def get_list_field_names(cls) -> List[str]:
+    def get_list_field_names(cls) -> list[str]:
         return ["side"]
 
 
 class DesignLengthInfo(DSeriesWrappedTableStructure):
-    designlengthinfo: List[Dict[str, float]]
+    designlengthinfo: list[dict[str, float]]
 
 
 class DesignLengthCalculation(DSeriesWrappedTableStructure):
-    designlengthcalculation: List[Dict[str, float]]
+    designlengthcalculation: list[dict[str, float]]
 
 
 class DesignSheetpileLength(DSeriesStructure):
-    design_length_info: Optional[DesignLengthInfo] = None
-    design_length_calculation: Optional[DesignLengthCalculation] = None
+    design_length_info: DesignLengthInfo | None = None
+    design_length_calculation: DesignLengthCalculation | None = None
 
 
 class PointsOnSheetpile(DSheetpilingWithNumberOfRowsTable):
-    pointsonsheetpile: List[Dict[str, float]]
+    pointsonsheetpile: list[dict[str, float]]
 
 
 class CurAnchorForceResults(DSheetpilingWithNumberOfRowsTable):
-    curanchorforceresults: List[Dict[str, float]]
+    curanchorforceresults: list[dict[str, float]]
 
 
 class BaseVerificationStructureProperties(DSeriesRepeatedGroupedProperties):
-    points_on_sheetpile: Optional[List[PointsOnSheetpile]] = None
-    construction_stage: Optional[List[OutputConstructionStage]] = None
+    points_on_sheetpile: list[PointsOnSheetpile] | None = None
+    construction_stage: list[OutputConstructionStage] | None = None
 
     @classmethod
-    def get_list_field_names(cls) -> List[str]:
+    def get_list_field_names(cls) -> list[str]:
         return ["points_on_sheetpile", "construction_stage"]
 
 
 class DSheetPilingOutputStructure(DSeriesRepeatedGroupedProperties):
     @classmethod
-    def get_list_field_names(cls) -> List[str]:
+    def get_list_field_names(cls) -> list[str]:
         return ["points_on_sheetpile", "construction_stage"]
 
     @classmethod
@@ -1309,79 +1309,65 @@ class DSheetPilingOutputStructure(DSeriesRepeatedGroupedProperties):
     calculation_type: str
 
     # General data
-    sheet_pile_elements: Optional[str] = None
-    calculated_displacements: Optional[str] = None
+    sheet_pile_elements: str | None = None
+    calculated_displacements: str | None = None
 
     # Standard, Kranz and Reliability calculation
-    points_on_sheetpile: Optional[List[PointsOnSheetpile]] = None
-    construction_stage: Optional[List[OutputConstructionStage]] = None
+    points_on_sheetpile: list[PointsOnSheetpile] | None = None
+    construction_stage: list[OutputConstructionStage] | None = None
 
     # Design Sheet Pile Length calculation
-    design_sheetpile_length: Optional[DesignSheetpileLength] = None
+    design_sheetpile_length: DesignSheetpileLength | None = None
 
     # Settlement by Vibration calculation
-    settlement_by_vibration: Optional[str] = None
+    settlement_by_vibration: str | None = None
 
     # Verify calculation including Overall Stability calculation
-    overall_partial_factor_set: Optional[str] = None
-    factors_for_overall_stability: Optional[str] = None
-    overall_stability_results: Optional[str] = None
+    overall_partial_factor_set: str | None = None
+    factors_for_overall_stability: str | None = None
+    overall_stability_results: str | None = None
 
     # Verify calculation according to CUR or EC7-NL with method B
-    factors_for_verification: Optional[str] = None
+    factors_for_verification: str | None = None
 
     # Verify calculation according to CUR or EC7-NL
-    verify_step_6____5_serviceability_limit_state: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    verify_step_6____5_multiplied_by_factor: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    verify_step_6____1_low_modulus_of_subgrade_reaction_and_high_passive_water_level: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    verify_step_6____2_high_modulus_of_subgrade_reaction_and_high_passive_water_level: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    verify_step_6____3_low_modulus_of_subgrade_reaction_and_low_passive_water_level: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    verify_step_6____4_high_modulus_of_subgrade_reaction_and_low_passive_water_level: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    cur_anchor_force_results: Optional[CurAnchorForceResults] = None
+    verify_step_6____5_serviceability_limit_state: BaseVerificationStructureProperties | None = None
+    verify_step_6____5_multiplied_by_factor: BaseVerificationStructureProperties | None = None
+    verify_step_6____1_low_modulus_of_subgrade_reaction_and_high_passive_water_level: BaseVerificationStructureProperties | None = None
+    verify_step_6____2_high_modulus_of_subgrade_reaction_and_high_passive_water_level: BaseVerificationStructureProperties | None = None
+    verify_step_6____3_low_modulus_of_subgrade_reaction_and_low_passive_water_level: BaseVerificationStructureProperties | None = None
+    verify_step_6____4_high_modulus_of_subgrade_reaction_and_low_passive_water_level: BaseVerificationStructureProperties | None = None
+    cur_anchor_force_results: CurAnchorForceResults | None = None
 
     # Verify calculation according to EC7-BE or EC7-General
-    verify_deformation_serviceability_limit_state: Optional[
-        BaseVerificationStructureProperties
-    ] = None
-    eurocode_1_set_1: Optional[BaseVerificationStructureProperties] = None
-    eurocode_1_set_2: Optional[BaseVerificationStructureProperties] = None
-    eurocode_2: Optional[BaseVerificationStructureProperties] = None
-    eurocode_3: Optional[BaseVerificationStructureProperties] = None
-    eurocode_belgium_set_1: Optional[BaseVerificationStructureProperties] = None
-    eurocode_belgium_set_2: Optional[BaseVerificationStructureProperties] = None
+    verify_deformation_serviceability_limit_state: BaseVerificationStructureProperties | None = None
+    eurocode_1_set_1: BaseVerificationStructureProperties | None = None
+    eurocode_1_set_2: BaseVerificationStructureProperties | None = None
+    eurocode_2: BaseVerificationStructureProperties | None = None
+    eurocode_3: BaseVerificationStructureProperties | None = None
+    eurocode_belgium_set_1: BaseVerificationStructureProperties | None = None
+    eurocode_belgium_set_2: BaseVerificationStructureProperties | None = None
 
     # Kranz calculation
-    angles_kranz_calculation: Optional[str] = None
-    kranz_calculation: Optional[str] = None
-    kranz_diagram_results: Optional[str] = None
+    angles_kranz_calculation: str | None = None
+    kranz_calculation: str | None = None
+    kranz_diagram_results: str | None = None
 
     # Resumes
-    resume: Optional[Resume] = None
-    anchors_and_struts_resume: Optional[str] = None
-    supports_resume: Optional[str] = None
-    maximum_anchor_force: Optional[str] = None
-    maximum_anchor_force_be_set_1: Optional[str] = None
-    maximum_summary_results: Optional[str] = None
-    maximum_summary_results_be_set_1: Optional[str] = None
-    warnings: Optional[str] = None
-    errors: Optional[str] = None
+    resume: Resume | None = None
+    anchors_and_struts_resume: str | None = None
+    supports_resume: str | None = None
+    maximum_anchor_force: str | None = None
+    maximum_anchor_force_be_set_1: str | None = None
+    maximum_summary_results: str | None = None
+    maximum_summary_results_be_set_1: str | None = None
+    warnings: str | None = None
+    errors: str | None = None
 
 
 class DSheetPilingStructure(DSeriesPilingParserStructure):
     input_data: DSheetPilingInputStructure = DSheetPilingInputStructure()
-    output_data: Optional[DSheetPilingOutputStructure] = None
+    output_data: DSheetPilingOutputStructure | None = None
 
     @property
     def is_valid(self) -> bool:

--- a/geolib/models/dsheetpiling/loads.py
+++ b/geolib/models/dsheetpiling/loads.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import Field, StringConstraints, field_validator
 from typing_extensions import Annotated
 
@@ -159,7 +157,7 @@ class SurchargeLoad(BaseDataClass):
     """
 
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
-    points: Annotated[List[Point], Field(min_length=1)]
+    points: Annotated[list[Point], Field(min_length=1)]
     verification_load_settings: VerificationLoadSettingsLoads = (
         VerificationLoadSettingsLoads()
     )

--- a/geolib/models/dsheetpiling/profiles.py
+++ b/geolib/models/dsheetpiling/profiles.py
@@ -3,9 +3,6 @@ Profile and Layer classes which are used by both D-Foundations and DSheetPiling.
 D-Foundations often requires more parameters, which are unused for DSheetPiling.
 
 """
-
-from typing import List
-
 from pydantic import Field, field_validator
 from typing_extensions import Annotated
 
@@ -25,8 +22,8 @@ class CPT(BaseDataClass):
         * Unify with DFoundations
     """
 
-    z: List[float]
-    qc: List[float]
+    z: list[float]
+    qc: list[float]
 
 
 class CPTRule(BaseDataClass):
@@ -46,7 +43,7 @@ class SoilProfile(BaseDataClass):
     """D-Sheetpiling Profile."""
 
     name: str
-    layers: Annotated[List[SoilLayer], Field(min_length=1)]
+    layers: Annotated[list[SoilLayer], Field(min_length=1)]
     coordinate: Point = Point(x=0, y=0)
 
     @classmethod

--- a/geolib/models/dsheetpiling/supports.py
+++ b/geolib/models/dsheetpiling/supports.py
@@ -1,5 +1,4 @@
 from enum import IntEnum
-from typing import Optional
 
 from pydantic import Field, PositiveFloat, StringConstraints
 from typing_extensions import Annotated
@@ -29,13 +28,13 @@ class Anchor(BaseDataClass):
 
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
     level: float
-    e_modulus: Optional[PositiveFloat] = None
-    cross_section: Optional[PositiveFloat] = None
-    wall_height_kranz: Optional[Annotated[float, Field(ge=0)]] = None
-    length: Optional[PositiveFloat] = None
-    angle: Optional[float] = None
+    e_modulus: PositiveFloat | None = None
+    cross_section: PositiveFloat | None = None
+    wall_height_kranz: Annotated[float, Field(ge=0)] | None = None
+    length: PositiveFloat | None = None
+    angle: float | None = None
     side: Side = Side.RIGHT
-    yield_force: Optional[Annotated[float, Field(ge=0)]] = None
+    yield_force: Annotated[float, Field(ge=0)] | None = None
 
     def to_internal(self) -> InternalAnchor:
         return InternalAnchor(**self.model_dump(exclude_none=True))
@@ -58,13 +57,13 @@ class Strut(BaseDataClass):
 
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
     level: float
-    e_modulus: Optional[PositiveFloat] = None
-    cross_section: Optional[PositiveFloat] = None
-    length: Optional[PositiveFloat] = None
-    angle: Optional[float] = None
-    buckling_force: Optional[Annotated[float, Field(ge=0)]] = None
+    e_modulus: PositiveFloat | None = None
+    cross_section: PositiveFloat | None = None
+    length: PositiveFloat | None = None
+    angle: float | None = None
+    buckling_force: Annotated[float, Field(ge=0)] | None = None
     side: Side = Side.RIGHT
-    pre_compression: Optional[PositiveFloat] = None
+    pre_compression: PositiveFloat | None = None
 
     def to_internal(self) -> InternalStrut:
         return InternalStrut(

--- a/geolib/models/dsheetpiling/surface.py
+++ b/geolib/models/dsheetpiling/surface.py
@@ -1,5 +1,3 @@
-from typing import List, Optional
-
 from pydantic import Field, StringConstraints, field_validator
 from typing_extensions import Annotated
 
@@ -21,9 +19,9 @@ class Surface(BaseDataClass):
     """
 
     name: Annotated[str, StringConstraints(min_length=1, max_length=50)]
-    points: Annotated[List[Point], Field(min_length=1)]
-    distribution_type: Optional[DistributionType] = None
-    std: Optional[Annotated[float, Field(ge=0.0)]] = None
+    points: Annotated[list[Point], Field(min_length=1)]
+    distribution_type: DistributionType | None = None
+    std: Annotated[float, Field(ge=0.0)] | None = None
 
     @classmethod
     def points_must_be_increasing_and_greater_or_equal_to_zero(cls, v):

--- a/geolib/models/dstability/analysis.py
+++ b/geolib/models/dstability/analysis.py
@@ -1,5 +1,4 @@
 import abc
-from typing import List
 
 from pydantic import Field, PositiveInt
 from typing_extensions import Annotated
@@ -223,7 +222,7 @@ class DStabilitySpencerAnalysisMethod(DStabilityAnalysisMethod):
     """
 
     _analysis_type: AnalysisType = AnalysisType.SPENCER
-    slipplane: List[Point]
+    slipplane: list[Point]
     slip_plane_constraints: DStabilityGeneticSlipPlaneConstraints = (
         DStabilityGeneticSlipPlaneConstraints()
     )
@@ -242,15 +241,15 @@ class DStabilitySpencerGeneticAnalysisMethod(DStabilityAnalysisMethod):
 
     Args:
         options_type (OptionsType): DEFAULT or THOROUGH, defaults to DEFAULT
-        slip_plane_a (List[Point]): upper slip plane boundary
-        slip_plane_b (List[Point]): lower slip line boundary
+        slip_plane_a (list[Point]): upper slip plane boundary
+        slip_plane_b (list[Point]): lower slip line boundary
         slip_plane_constraints (DStabilityGeneticSlipPlaneConstraints): constraints for the slip plane
     """
 
     _analysis_type: AnalysisType = AnalysisType.SPENCER_GENETIC
     options_type: OptionsType = OptionsType.DEFAULT
-    slip_plane_a: List[Point]
-    slip_plane_b: List[Point]
+    slip_plane_a: list[Point]
+    slip_plane_b: list[Point]
     slip_plane_constraints: DStabilityGeneticSlipPlaneConstraints = (
         DStabilityGeneticSlipPlaneConstraints()
     )

--- a/geolib/models/dstability/dstability_model.py
+++ b/geolib/models/dstability/dstability_model.py
@@ -1,7 +1,7 @@
 import abc
 from enum import Enum
 from pathlib import Path
-from typing import BinaryIO, List, Optional, Set, Type, Union
+from typing import BinaryIO
 
 import matplotlib.pyplot as plt
 from pydantic import DirectoryPath, FilePath
@@ -80,7 +80,7 @@ class DStabilityModel(BaseModel):
         self.current_id = self.datastructure.get_unique_id()
 
     @property
-    def parser_provider_type(self) -> Type[DStabilityParserProvider]:
+    def parser_provider_type(self) -> type[DStabilityParserProvider]:
         return DStabilityParserProvider
 
     @property
@@ -109,11 +109,11 @@ class DStabilityModel(BaseModel):
         self.current_id = self.datastructure.get_unique_id()
 
     @property
-    def waternets(self) -> List[Waternet]:
+    def waternets(self) -> list[Waternet]:
         return self.datastructure.waternets
 
     @property
-    def output(self) -> List[DStabilityResult]:
+    def output(self) -> list[DStabilityResult]:
         def _get_result_or_none(scenario_index, calculation_index) -> DStabilityResult:
             if self.has_result(
                 scenario_index=int(scenario_index),
@@ -140,15 +140,15 @@ class DStabilityModel(BaseModel):
 
     def has_result(
         self,
-        scenario_index: Optional[int] = None,
-        calculation_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        calculation_index: int | None = None,
     ) -> bool:
         """
         Returns whether a calculation has a result.
 
         Args:
-            scenario_index (Optional[int]): Index of a scenario, if None the current scenario is used.
-            calculation_index (Optional[int]): Index of a calculation, if None the current calculation is used.
+            scenario_index (int | None): Index of a scenario, if None the current scenario is used.
+            calculation_index (int | None): Index of a calculation, if None the current calculation is used.
 
         Returns:
             bool: Value indicating whether the calculation has a result.
@@ -162,15 +162,15 @@ class DStabilityModel(BaseModel):
 
     def get_result(
         self,
-        scenario_index: Optional[int] = None,
-        calculation_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        calculation_index: int | None = None,
     ) -> DStabilityResult:
         """
         Returns the results of a calculation. Calculation results are based on analysis type and calculation type.
 
         Args:
-            scenario_index (Optional[int]): Index of a scenario, if None is supplied the result of the current scenario is returned.
-            calculation_index (Optional[int]): Index of a calculation, if None is supplied the result of the current calculation is returned.
+            scenario_index (int | None): Index of a scenario, if None is supplied the result of the current scenario is returned.
+            calculation_index (int | None): Index of a calculation, if None is supplied the result of the current calculation is returned.
 
         Returns:
             DStabilityResult: The analysis results of the stage.
@@ -187,7 +187,7 @@ class DStabilityModel(BaseModel):
         return result
 
     def _get_result_substructure(
-        self, scenario_index: Optional[int], calculation_index: Optional[int]
+        self, scenario_index: int | None, calculation_index: int | None
     ) -> DStabilityResult:
         scenario_index = self.get_scenario_index(scenario_index)
         calculation_index = self.get_calculation_index(calculation_index)
@@ -233,18 +233,18 @@ class DStabilityModel(BaseModel):
 
     def get_slipcircle_result(
         self,
-        scenario_index: Optional[int] = None,
-        calculation_index: Optional[int] = None,
-    ) -> Union[BishopSlipCircleResult, UpliftVanSlipCircleResult]:
+        scenario_index: int | None = None,
+        calculation_index: int | None = None,
+    ) -> BishopSlipCircleResult | UpliftVanSlipCircleResult:
         """
         Get the slipcircle(s) of the calculation result of a given stage.
 
         Args:
-            scenario_index (Optional[int]): scenario for which to get the available results
-            calculation_index (Optional[int]): calculation for which to get the available results
+            scenario_index (int | None): scenario for which to get the available results
+            calculation_index (int | None): calculation for which to get the available results
 
         Returns:
-            Union[BishopSlipCircleResult, UpliftVanSlipCircleResult]: the slipcircle for the given calculation
+            BishopSlipCircleResult | UpliftVanSlipCircleResult: the slipcircle for the given calculation
 
         Raises:
             ValueError: Result is not available for provided scenario and calculation index
@@ -255,15 +255,15 @@ class DStabilityModel(BaseModel):
 
     def get_slipplane_result(
         self,
-        scenario_index: Optional[int] = None,
-        calculation_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        calculation_index: int | None = None,
     ) -> SpencerSlipPlaneResult:
         """
         Get the slipplanes of the calculations result of a calculation.
 
         Args:
-            scenario_index (Optional[int]): scenario for which to get the available results
-            calculation_index (Optional[int]): calculation for which to get the available results
+            scenario_index (int | None): scenario for which to get the available results
+            calculation_index (int | None): calculation for which to get the available results
 
         Returns:
             SpencerSlipPlaneResult: the slip plane for the given calculation
@@ -353,7 +353,7 @@ class DStabilityModel(BaseModel):
             f"No reinforcements found for stage {stage_index} in scenario {scenario_index}."
         )
 
-    def serialize(self, location: Union[FilePath, DirectoryPath, BinaryIO]):
+    def serialize(self, location: FilePath | DirectoryPath | BinaryIO):
         """Support serializing to directory while developing for debugging purposes."""
         if isinstance(location, Path) and location.is_dir():
             serializer = DStabilityInputSerializer(ds=self.datastructure)
@@ -391,7 +391,7 @@ class DStabilityModel(BaseModel):
 
     def add_stage(
         self,
-        scenario_index: Optional[int] = None,
+        scenario_index: int | None = None,
         label: str = "Stage",
         notes: str = "",
         set_current=True,
@@ -399,7 +399,7 @@ class DStabilityModel(BaseModel):
         """Add a new stage to the model at the given scenario index.
 
         Args:
-            scenario_index (Optional[int]): The scenario index to add the stage to, defaults to the current scenario.
+            scenario_index (int | None): The scenario index to add the stage to, defaults to the current scenario.
             label (str): Label for the stage.
             notes (str): Notes for the stage.
             set_current (bool): Whether to make the new stage the current stage.
@@ -421,7 +421,7 @@ class DStabilityModel(BaseModel):
 
     def add_calculation(
         self,
-        scenario_index: Optional[int] = None,
+        scenario_index: int | None = None,
         label: str = "Calculation",
         notes: str = "",
         set_current: bool = True,
@@ -429,7 +429,7 @@ class DStabilityModel(BaseModel):
         """Add a new calculation to the model.
 
         Args:
-            scenario_index (Optional[int]): The scenario index to add the calculation to, defaults to the current scenario.
+            scenario_index (int | None): The scenario index to add the calculation to, defaults to the current scenario.
             label (str): Label for the calculation.
             notes (str): Notes for the calculation.
             set_current (bool): Whether to make the new calculation the current calculation.
@@ -450,7 +450,7 @@ class DStabilityModel(BaseModel):
         return new_calculation_index
 
     @property
-    def scenarios(self) -> List[Scenario]:
+    def scenarios(self) -> list[Scenario]:
         return self.datastructure.scenarios
 
     def add_soil(self, soil: Soil) -> int:
@@ -478,23 +478,23 @@ class DStabilityModel(BaseModel):
 
     def add_layer(
         self,
-        points: List[Point],
+        points: list[Point],
         soil_code: str,
         label: str = "",
         notes: str = "",
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> int:
         """
         Add a soil layer to the model
 
         Args:
-            points (List[Point]): list of Point classes, in clockwise order (non closed simple polygon)
+            points (list[Point]): list of Point classes, in clockwise order (non closed simple polygon)
             soil_code (str): code of the soil for this layer
             label (str): label defaults to empty string
             notes (str): notes defaults to empty string
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario
-            stage_index (Optional[int]): stage to add to, defaults to the current stage
+            scenario_index (int | None): scenario to add to, defaults to the current scenario
+            stage_index (int | None): stage to add to, defaults to the current stage
 
         Returns:
             int: id of the added layer
@@ -530,7 +530,7 @@ class DStabilityModel(BaseModel):
         soil_layers.add_soillayer(layer_id=new_layer.Id, soil_id=soil.Id)
         return int(new_layer.Id)
 
-    def make_points_valid(self, points: List[Point]) -> List[PersistablePoint]:
+    def make_points_valid(self, points: list[Point]) -> list[PersistablePoint]:
         valid_points = make_valid(self.geolib_points_to_shapely_polygon(points))
         return self.to_dstability_points(valid_points)
 
@@ -550,7 +550,7 @@ class DStabilityModel(BaseModel):
             return linestring1, linestring2
 
     def add_layer_and_connect_points(
-        self, current_layers: List[PersistableLayer], new_layer: PersistableLayer
+        self, current_layers: list[PersistableLayer], new_layer: PersistableLayer
     ):
         """Adds a new layer to the list of layers and connects the points of the new layer to the existing layers."""
 
@@ -574,22 +574,22 @@ class DStabilityModel(BaseModel):
                     self.to_dstability_points(linestring2)
                 )
 
-    def to_shapely_linestring(self, points: List[PersistablePoint]) -> LineString:
+    def to_shapely_linestring(self, points: list[PersistablePoint]) -> LineString:
         converted_points = [(p.X, p.Z) for p in points]
         converted_points.append(converted_points[0])
         return LineString(converted_points)
 
     def dstability_points_to_shapely_polygon(
-        self, points: List[PersistablePoint]
+        self, points: list[PersistablePoint]
     ) -> Polygon:
         return Polygon([(p.X, p.Z) for p in points])
 
-    def geolib_points_to_shapely_polygon(self, points: List[Point]) -> Polygon:
+    def geolib_points_to_shapely_polygon(self, points: list[Point]) -> Polygon:
         return Polygon([(p.x, p.z) for p in points])
 
     def to_dstability_points(
-        self, shapely_object: Union[LineString, Polygon]
-    ) -> List[PersistablePoint]:
+        self, shapely_object: LineString | Polygon
+    ) -> list[PersistablePoint]:
         if isinstance(shapely_object, LineString):
             coords = shapely_object.coords
         elif isinstance(shapely_object, Polygon):
@@ -642,23 +642,23 @@ class DStabilityModel(BaseModel):
 
     def add_head_line(
         self,
-        points: List[Point],
+        points: list[Point],
         label: str = "",
         notes: str = "",
         is_phreatic_line: bool = False,
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> int:
         """
         Add head line to the model
 
         Args:
-            points (List[Point]): list of Point classes
+            points (list[Point]): list of Point classes
             label (str): label defaults to empty string
             notes (str): notes defaults to empty string
             is_phreatic_line (bool): set as phreatic line, defaults to False
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario
-            stage_index (Optional[int]): stage to add to, defaults to the current stage
+            scenario_index (int | None): scenario to add to, defaults to the current scenario
+            stage_index (int | None): stage to add to, defaults to the current stage
 
         Returns:
             bool: id of the added headline
@@ -675,25 +675,25 @@ class DStabilityModel(BaseModel):
 
     def add_reference_line(
         self,
-        points: List[Point],
-        bottom_headline_id: Optional[str] = None,
-        top_head_line_id: Optional[str] = None,
+        points: list[Point],
+        bottom_headline_id: str | None = None,
+        top_head_line_id: str | None = None,
         label: str = "",
         notes: str = "",
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> int:
         """
         Add reference line to the model
 
         Args:
-            points (List[Point]): list of Point classes
+            points (list[Point]): list of Point classes
             bottom_headline_id (int): id of the headline to use as the bottom headline
             top_head_line_id (int): id of the headline to use as the top headline
             label (str): label defaults to empty string
             notes (str): notes defaults to empty string
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario
-            stage_index (Optional[int]): stage to add to, defaults to the current stage
+            scenario_index (int | None): scenario to add to, defaults to the current scenario
+            stage_index (int | None): stage to add to, defaults to the current stage
 
         Returns:
             int: id of the added reference line
@@ -716,16 +716,16 @@ class DStabilityModel(BaseModel):
     def add_state_point(
         self,
         state_point: DStabilityStatePoint,
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> int:
         """
         Add state point to the model
 
         Args:
             state_point (DStabilityStatePoint): DStabilityStatePoint class
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario
-            stage_index (Optional[int]): stage to add to, defaults to the current stage
+            scenario_index (int | None): scenario to add to, defaults to the current scenario
+            stage_index (int | None): stage to add to, defaults to the current stage
 
         Returns:
             int: id of the added add_state_point
@@ -751,10 +751,10 @@ class DStabilityModel(BaseModel):
 
     def add_state_line(
         self,
-        points: List[Point],
-        state_points: List[DStabilityStateLinePoint],
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        points: list[Point],
+        state_points: list[DStabilityStateLinePoint],
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> int:
         """
         Add state line. From the Soils, only the state parameters are used.
@@ -763,10 +763,10 @@ class DStabilityModel(BaseModel):
         state_point are a list of DStabilityStateLinePoint where ONLY the x is used, the Z will be calculated
 
         Args:
-            points (List[Point]): The geometry points of the state line.
-            state_point (List[DStabilityStatePoint]): The list of state point values.
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario.
-            stage_index (Optional[int]): stage to add to, defaults to the current stage.
+            points (list[Point]): The geometry points of the state line.
+            state_point (list[DStabilityStatePoint]): The list of state point values.
+            scenario_index (int | None): scenario to add to, defaults to the current scenario.
+            stage_index (int | None): stage to add to, defaults to the current stage.
 
         Returns:
             PersistableStateLine: The created state line
@@ -792,17 +792,17 @@ class DStabilityModel(BaseModel):
 
     def add_state_correlation(
         self,
-        correlated_state_ids: List[int],
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        correlated_state_ids: list[int],
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ):
         """
         Add state correlation between the given state point ids.
 
         Args:
-            correlated_state_ids (List[int]): The state point ids to correlate.
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario.
-            stage_index (Optional[int]): stage to add to, defaults to the current stage.
+            correlated_state_ids (list[int]): The state point ids to correlate.
+            scenario_index (int | None): scenario to add to, defaults to the current scenario.
+            stage_index (int | None): stage to add to, defaults to the current stage.
 
         Returns:
             None
@@ -826,11 +826,11 @@ class DStabilityModel(BaseModel):
 
     def add_excavation(
         self,
-        points: List[Point],
+        points: list[Point],
         label: str,
         notes: str = "",
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ):
         scenario_index = self.get_scenario_index(scenario_index)
         stage_index = self.get_stage_index(stage_index)
@@ -845,9 +845,9 @@ class DStabilityModel(BaseModel):
     def add_load(
         self,
         load: DStabilityLoad,
-        consolidations: Optional[List[Consolidation]] = None,
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        consolidations: list[Consolidation] | None = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> None:
         """Add a load to the object.
 
@@ -858,8 +858,8 @@ class DStabilityModel(BaseModel):
 
         Args:
             load: A subclass of DStabilityLoad.
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario.
-            stage_index (Optional[int]): stage to add to, defaults to the current stage.
+            scenario_index (int | None): scenario to add to, defaults to the current scenario.
+            stage_index (int | None): stage to add to, defaults to the current stage.
 
         Raises:
             ValueError: When the provided load is no subclass of DStabilityLoad, an invalid stage_index is provided, or the datastructure is no longer valid.
@@ -889,9 +889,9 @@ class DStabilityModel(BaseModel):
     def add_soil_layer_consolidations(
         self,
         soil_layer_id: int,
-        consolidations: Optional[List[Consolidation]] = None,
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        consolidations: list[Consolidation] | None = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> None:
         """Add consolidations for a layer (layerload).
 
@@ -902,8 +902,8 @@ class DStabilityModel(BaseModel):
         Args:
             soil_layer_id: Consolidation is set for this soil layer id.
             consolidations: List of Consolidation. Must contain a Consolidation for every other layer.
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario.
-            stage_index (Optional[int]): stage to add to, defaults to the current stage.
+            scenario_index (int | None): scenario to add to, defaults to the current scenario.
+            stage_index (int | None): stage to add to, defaults to the current stage.
 
         Raises:
             ValueError: When the provided load is no subclass of DStabilityLoad, an invalid stage_index is provided, or the datastructure is no longer valid.
@@ -935,8 +935,8 @@ class DStabilityModel(BaseModel):
         self,
         scenario_index: int,
         stage_index: int,
-        exclude_soil_layer_id: Optional[int] = None,
-    ) -> List[Consolidation]:
+        exclude_soil_layer_id: int | None = None,
+    ) -> list[Consolidation]:
         """Length of the consolidations is equal to the amount of soil layers.
 
         If exclude_soil_layer_id is provided, that specific soil layer id is not included in the consolidations.
@@ -951,13 +951,13 @@ class DStabilityModel(BaseModel):
 
     def _verify_consolidations(
         self,
-        consolidations: List[Consolidation],
+        consolidations: list[Consolidation],
         scenario_index: int,
         stage_index: int,
-        exclude_soil_layer_id: Optional[int] = None,
+        exclude_soil_layer_id: int | None = None,
     ) -> None:
         if self.datastructure.has_soil_layers(scenario_index, stage_index):
-            consolidation_soil_layer_ids: Set[str] = {
+            consolidation_soil_layer_ids: set[str] = {
                 str(c.layer_id) for c in consolidations
             }
             soil_layer_ids = self._get_soil_layers(scenario_index, stage_index).get_ids(
@@ -974,15 +974,15 @@ class DStabilityModel(BaseModel):
     def add_reinforcement(
         self,
         reinforcement: DStabilityReinforcement,
-        scenario_index: Optional[int] = None,
-        stage_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        stage_index: int | None = None,
     ) -> None:
         """Add a reinforcement to the model.
 
         Args:
             reinforcement: A subclass of DStabilityReinforcement.
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario.
-            stage_index (Optional[int]): stage to add to, defaults to the current stage.
+            scenario_index (int | None): scenario to add to, defaults to the current scenario.
+            stage_index (int | None): stage to add to, defaults to the current stage.
 
         Returns:
             int: Assigned id of the reinforcements (collection object of all reinforcements for a stage).
@@ -1007,7 +1007,7 @@ class DStabilityModel(BaseModel):
                 f"No reinforcements found for scenario {scenario_index} stage {stage_index}"
             )
 
-    def add_soil_correlation(self, list_correlated_soil_ids: List[str]):
+    def add_soil_correlation(self, list_correlated_soil_ids: list[str]):
         """Add a soil correlation to the model.
 
         Args:
@@ -1018,15 +1018,15 @@ class DStabilityModel(BaseModel):
     def set_model(
         self,
         analysis_method: DStabilityAnalysisMethod,
-        scenario_index: Optional[int] = None,
-        calculation_index: Optional[int] = None,
+        scenario_index: int | None = None,
+        calculation_index: int | None = None,
     ) -> None:
         """Sets the model and applies the given parameters
 
         Args:
             analysis_method (DStabilityAnalysisMethod): A subclass of DStabilityAnalysisMethod.
-            scenario_index (Optional[int]): scenario to add to, defaults to the current scenario
-            calculation_index (Optional[int]): calculation to add to, defaults to the current calculation
+            scenario_index (int | None): scenario to add to, defaults to the current scenario
+            calculation_index (int | None): calculation to add to, defaults to the current calculation
 
         Raises:
             ValueError: When the provided analysis method is no subclass of DStabilityAnalysisMethod,
@@ -1057,19 +1057,19 @@ class DStabilityModel(BaseModel):
                 f"Unknown analysis method {analysis_method.analysis_type.value} found"
             )
 
-    def get_scenario_index(self, scenario_index: Optional[int]):
+    def get_scenario_index(self, scenario_index: int | None):
         if scenario_index is None:
             return self.current_scenario
         else:
             return scenario_index
 
-    def get_stage_index(self, stage_index: Optional[int]):
+    def get_stage_index(self, stage_index: int | None):
         if stage_index is None:
             return self.current_stage
         else:
             return stage_index
 
-    def get_calculation_index(self, calculation_index: Optional[int]):
+    def get_calculation_index(self, calculation_index: int | None):
         if calculation_index is None:
             return self.current_calculation
         else:
@@ -1078,7 +1078,7 @@ class DStabilityModel(BaseModel):
     @staticmethod
     def get_soil_id_from_layer_id(
         layers: SoilLayerCollection, layer_id: str
-    ) -> Union[str, None]:
+    ) -> str | None:
         for layer in layers.SoilLayers:
             if layer.LayerId == layer_id:
                 return layer.SoilId
@@ -1108,7 +1108,7 @@ class DStabilityModel(BaseModel):
         return color.replace("#80", "#")
 
     def plot(
-        self, scenario_index: Optional[int] = None, stage_index: Optional[int] = None
+        self, scenario_index: int | None = None, stage_index: int | None = None
     ):
         geometry = self._get_geometry(scenario_index, stage_index)
         layers_collection = self._get_soil_layers(scenario_index, stage_index)

--- a/geolib/models/dstability/dstability_parserprovider.py
+++ b/geolib/models/dstability/dstability_parserprovider.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Tuple, Type, _GenericAlias
+from typing import _GenericAlias
 from zipfile import ZipFile
 
 from pydantic import DirectoryPath, FilePath
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 class DStabilityParser(BaseParser):
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".json", ""]
 
     @property
-    def structure(self) -> Type[DStabilityStructure]:
+    def structure(self) -> type[DStabilityStructure]:
         return DStabilityStructure
 
     def can_parse(self, filename: FilePath) -> bool:
@@ -44,7 +44,7 @@ class DStabilityParser(BaseParser):
 
         return self.structure(**ds)
 
-    def __parse_folder(self, fieldtype, filepath: DirectoryPath) -> List:
+    def __parse_folder(self, fieldtype, filepath: DirectoryPath) -> list:
         out = []
         folder = filepath / fieldtype.structure_group()
 
@@ -70,7 +70,7 @@ class DStabilityParser(BaseParser):
 
 class DStabilityZipParser(DStabilityParser):
     @property
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         return [".stix"]
 
     def can_parse(self, filename: FilePath) -> bool:
@@ -98,13 +98,13 @@ class DStabilityParserProvider(BaseParserProvider):
     _output_parsers = None
 
     @property
-    def input_parsers(self) -> Tuple[DStabilityParser, DStabilityZipParser]:
+    def input_parsers(self) -> tuple[DStabilityParser, DStabilityZipParser]:
         if not self._input_parsers:
             self._input_parsers = (DStabilityZipParser(), DStabilityParser())
         return self._input_parsers
 
     @property
-    def output_parsers(self) -> Tuple[DStabilityParser, DStabilityZipParser]:
+    def output_parsers(self) -> tuple[DStabilityParser, DStabilityZipParser]:
         if not self._output_parsers:
             self._output_parsers = (DStabilityParser(), DStabilityZipParser())
         return self._output_parsers

--- a/geolib/models/dstability/dstability_validator.py
+++ b/geolib/models/dstability/dstability_validator.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Set
 
 from geolib.models.validators import BaseValidator
 
@@ -45,7 +44,7 @@ class DStabilityValidator(BaseValidator):
         """Each layer load must have a consolidation degree for each soil layer"""
         for scenario_index, _ in enumerate(self.ds.scenarios):
             for stage_index, _ in enumerate(self.ds.scenarios[scenario_index].Stages):
-                soil_layer_ids: Set[str] = {
+                soil_layer_ids: set[str] = {
                     layer.LayerId
                     for layer in self.ds._get_soil_layers(
                         scenario_index, stage_index
@@ -55,13 +54,13 @@ class DStabilityValidator(BaseValidator):
                 if len(soil_layer_ids) == 0:
                     return True
 
-                layer_load_layer_ids: Set[str] = set()
+                layer_load_layer_ids: set[str] = set()
                 for layer_load in self.ds._get_loads(
                     scenario_index, stage_index
                 ).LayerLoads:
                     layer_load_layer_ids.add(layer_load.LayerId)
 
-                    consolidation_layer_id_references: Set[str] = set()
+                    consolidation_layer_id_references: set[str] = set()
                     for consolidation in layer_load.Consolidations:
                         consolidation_layer_id_references.add(consolidation.LayerId)
                         if consolidation.LayerId is None:

--- a/geolib/models/dstability/internal.py
+++ b/geolib/models/dstability/internal.py
@@ -7,7 +7,6 @@ from datetime import date, datetime
 from enum import Enum
 from itertools import chain
 from math import isfinite
-from typing import Dict, List, Optional, Set, Tuple, Union
 
 from pydantic import Field, ValidationError, field_validator, model_validator
 from typing_extensions import Annotated
@@ -57,7 +56,7 @@ class UpliftVanSlipCircleResult(DStabilityBaseModelStructure):
 
 
 class SpencerSlipPlaneResult(DStabilityBaseModelStructure):
-    slipplane: List[Point]
+    slipplane: list[Point]
 
 
 class DStabilitySubStructure(DStabilityBaseModelStructure):
@@ -73,15 +72,15 @@ class DStabilitySubStructure(DStabilityBaseModelStructure):
 
 # waternet schema
 class PersistablePoint(DStabilityBaseModelStructure):
-    X: Optional[Union[float, str]] = "NaN"
-    Z: Optional[Union[float, str]] = "NaN"
+    X: float | str | None = "NaN"
+    Z: float | str | None = "NaN"
 
 
 class PersistableHeadLine(DStabilityBaseModelStructure):
-    Id: Optional[str] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    Points: Optional[List[Optional[PersistablePoint]]] = None
+    Id: str | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    Points: list[PersistablePoint | None] | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -91,12 +90,12 @@ class PersistableHeadLine(DStabilityBaseModelStructure):
 
 
 class PersistableReferenceLine(DStabilityBaseModelStructure):
-    BottomHeadLineId: Optional[str] = None
-    Id: Optional[str] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    TopHeadLineId: Optional[str] = None
+    BottomHeadLineId: str | None = None
+    Id: str | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    Points: list[PersistablePoint | None] | None = None
+    TopHeadLineId: str | None = None
 
     @field_validator("Id", "TopHeadLineId", "BottomHeadLineId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -116,12 +115,12 @@ class Waternet(DStabilitySubStructure):
     def structure_name(cls) -> str:
         return "waternets"
 
-    Id: Optional[str] = None
-    ContentVersion: Optional[str] = "2"
-    PhreaticLineId: Optional[str] = None
-    HeadLines: List[PersistableHeadLine] = []
-    ReferenceLines: List[PersistableReferenceLine] = []
-    UnitWeightWater: Optional[float] = 9.81
+    Id: str | None = None
+    ContentVersion: str | None = "2"
+    PhreaticLineId: str | None = None
+    HeadLines: list[PersistableHeadLine] = []
+    ReferenceLines: list[PersistableReferenceLine] = []
+    UnitWeightWater: float | None = 9.81
 
     @field_validator("Id", "PhreaticLineId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -151,7 +150,7 @@ class Waternet(DStabilitySubStructure):
         head_line_id: str,
         label: str,
         notes: str,
-        points: List[Point],
+        points: list[Point],
         is_phreatic_line: bool,
     ) -> PersistableHeadLine:
         head_line = PersistableHeadLine(Id=head_line_id, Label=label, Notes=notes)
@@ -168,9 +167,9 @@ class Waternet(DStabilitySubStructure):
         reference_line_id: str,
         label: str,
         notes: str,
-        points: List[Point],
-        bottom_head_line_id: Optional[str] = None,
-        top_head_line_id: Optional[str] = None,
+        points: list[Point],
+        bottom_head_line_id: str | None = None,
+        top_head_line_id: str | None = None,
     ) -> PersistableReferenceLine:
         reference_line = PersistableReferenceLine(
             Id=reference_line_id, Label=label, Notes=notes
@@ -197,18 +196,18 @@ class Waternet(DStabilitySubStructure):
 
 
 class PersistableDitchCharacteristics(DStabilityBaseModelStructure):
-    DitchBottomEmbankmentSide: Optional[Union[float, str]] = "NaN"
-    DitchBottomLandSide: Optional[Union[float, str]] = "NaN"
-    DitchEmbankmentSide: Optional[Union[float, str]] = "NaN"
-    DitchLandSide: Optional[Union[float, str]] = "NaN"
+    DitchBottomEmbankmentSide: float | str | None = "NaN"
+    DitchBottomLandSide: float | str | None = "NaN"
+    DitchEmbankmentSide: float | str | None = "NaN"
+    DitchLandSide: float | str | None = "NaN"
 
 
 class PersistableEmbankmentCharacteristics(DStabilityBaseModelStructure):
-    EmbankmentToeLandSide: Optional[Union[float, str]] = "NaN"
-    EmbankmentToeWaterSide: Optional[Union[float, str]] = "NaN"
-    EmbankmentTopLandSide: Optional[Union[float, str]] = "NaN"
-    EmbankmentTopWaterSide: Optional[Union[float, str]] = "NaN"
-    ShoulderBaseLandSide: Optional[Union[float, str]] = "NaN"
+    EmbankmentToeLandSide: float | str | None = "NaN"
+    EmbankmentToeWaterSide: float | str | None = "NaN"
+    EmbankmentTopLandSide: float | str | None = "NaN"
+    EmbankmentTopWaterSide: float | str | None = "NaN"
+    ShoulderBaseLandSide: float | str | None = "NaN"
 
 
 class EmbankmentSoilScenarioEnum(str, Enum):
@@ -221,41 +220,41 @@ class EmbankmentSoilScenarioEnum(str, Enum):
 class WaternetCreatorSettings(DStabilitySubStructure):
     """waternetcreatorsettings/waternetcreatorsettings_x.json"""
 
-    AdjustForUplift: Optional[bool] = False
-    AquiferInsideAquitardLayerId: Optional[str] = None
-    AquiferLayerId: Optional[str] = None
-    AquiferLayerInsideAquitardLeakageLengthInwards: Optional[Union[float, str]] = "NaN"
-    AquiferLayerInsideAquitardLeakageLengthOutwards: Optional[Union[float, str]] = "NaN"
-    AquitardHeadLandSide: Optional[Union[float, str]] = "NaN"
-    AquitardHeadWaterSide: Optional[Union[float, str]] = "NaN"
-    ContentVersion: Optional[str] = "2"
-    DitchCharacteristics: Optional[PersistableDitchCharacteristics] = (
+    AdjustForUplift: bool | None = False
+    AquiferInsideAquitardLayerId: str | None = None
+    AquiferLayerId: str | None = None
+    AquiferLayerInsideAquitardLeakageLengthInwards: float | str | None = "NaN"
+    AquiferLayerInsideAquitardLeakageLengthOutwards: float | str | None = "NaN"
+    AquitardHeadLandSide: float | str | None = "NaN"
+    AquitardHeadWaterSide: float | str | None = "NaN"
+    ContentVersion: str | None = "2"
+    DitchCharacteristics: PersistableDitchCharacteristics | None = (
         PersistableDitchCharacteristics()
     )
-    DrainageConstruction: Optional[PersistablePoint] = PersistablePoint()
-    EmbankmentCharacteristics: Optional[PersistableEmbankmentCharacteristics] = (
+    DrainageConstruction: PersistablePoint | None = PersistablePoint()
+    EmbankmentCharacteristics: PersistableEmbankmentCharacteristics | None = (
         PersistableEmbankmentCharacteristics()
     )
     EmbankmentSoilScenario: EmbankmentSoilScenarioEnum = (
         EmbankmentSoilScenarioEnum.CLAY_EMBANKMENT_ON_CLAY
     )
-    Id: Optional[str] = None
-    InitialLevelEmbankmentTopLandSide: Optional[Union[float, str]] = "NaN"
-    InitialLevelEmbankmentTopWaterSide: Optional[Union[float, str]] = "NaN"
-    IntrusionLength: Optional[Union[float, str]] = "NaN"
-    IsAquiferLayerInsideAquitard: Optional[bool] = False
-    IsDitchPresent: Optional[bool] = False
-    IsDrainageConstructionPresent: Optional[bool] = False
-    MeanWaterLevel: Optional[Union[float, str]] = "NaN"
-    NormativeWaterLevel: Optional[Union[float, str]] = "NaN"
-    OffsetEmbankmentToeLandSide: Optional[Union[float, str]] = "NaN"
-    OffsetEmbankmentTopLandSide: Optional[Union[float, str]] = "NaN"
-    OffsetEmbankmentTopWaterSide: Optional[Union[float, str]] = "NaN"
-    OffsetShoulderBaseLandSide: Optional[Union[float, str]] = "NaN"
-    PleistoceneLeakageLengthInwards: Optional[Union[float, str]] = "NaN"
-    PleistoceneLeakageLengthOutwards: Optional[Union[float, str]] = "NaN"
-    UseDefaultOffsets: Optional[bool] = True
-    WaterLevelHinterland: Optional[Union[float, str]] = "NaN"
+    Id: str | None = None
+    InitialLevelEmbankmentTopLandSide: float | str | None = "NaN"
+    InitialLevelEmbankmentTopWaterSide: float | str | None = "NaN"
+    IntrusionLength: float | str | None = "NaN"
+    IsAquiferLayerInsideAquitard: bool | None = False
+    IsDitchPresent: bool | None = False
+    IsDrainageConstructionPresent: bool | None = False
+    MeanWaterLevel: float | str | None = "NaN"
+    NormativeWaterLevel: float | str | None = "NaN"
+    OffsetEmbankmentToeLandSide: float | str | None = "NaN"
+    OffsetEmbankmentTopLandSide: float | str | None = "NaN"
+    OffsetEmbankmentTopWaterSide: float | str | None = "NaN"
+    OffsetShoulderBaseLandSide: float | str | None = "NaN"
+    PleistoceneLeakageLengthInwards: float | str | None = "NaN"
+    PleistoceneLeakageLengthOutwards: float | str | None = "NaN"
+    UseDefaultOffsets: bool | None = True
+    WaterLevelHinterland: float | str | None = "NaN"
 
     field_validator("Id", "AquiferLayerId", mode="before")
 
@@ -287,19 +286,19 @@ class PersistableStress(DStabilityBaseModelStructure):
     PopStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
-    StateType: Optional[InternalStateTypeEnum] = None
+    StateType: InternalStateTypeEnum | None = None
     YieldStress: float = 0.0
 
 
 class PersistableStateLinePoint(DStabilityBaseModelStructure):
-    Above: Optional[PersistableStress] = None
-    Below: Optional[PersistableStress] = None
-    Id: Optional[str] = None
-    IsAboveAndBelowCorrelated: Optional[bool] = None
-    IsProbabilistic: Optional[bool] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    X: Optional[Union[float, str]] = "NaN"
+    Above: PersistableStress | None = None
+    Below: PersistableStress | None = None
+    Id: str | None = None
+    IsAboveAndBelowCorrelated: bool | None = None
+    IsProbabilistic: bool | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    X: float | str | None = "NaN"
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -309,18 +308,18 @@ class PersistableStateLinePoint(DStabilityBaseModelStructure):
 
 
 class PersistableStateLine(DStabilityBaseModelStructure):
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    Values: Optional[List[Optional[PersistableStateLinePoint]]] = None
+    Points: list[PersistablePoint | None] | None = None
+    Values: list[PersistableStateLinePoint | None] | None = None
 
 
 class PersistableStatePoint(DStabilityBaseModelStructure):
-    Id: Optional[str] = None
-    IsProbabilistic: Optional[bool] = None
-    Label: Optional[str] = ""
-    LayerId: Optional[str] = None
-    Notes: Optional[str] = ""
-    Point: Optional[PersistablePoint] = None
-    Stress: Optional[PersistableStress] = None
+    Id: str | None = None
+    IsProbabilistic: bool | None = None
+    Label: str | None = ""
+    LayerId: str | None = None
+    Notes: str | None = ""
+    Point: PersistablePoint | None = None
+    Stress: PersistableStress | None = None
 
     @field_validator("Id", "LayerId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -340,10 +339,10 @@ class State(DStabilitySubStructure):
     def structure_group(cls) -> str:
         return "states"
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    StateLines: List[PersistableStateLine] = []
-    StatePoints: List[PersistableStatePoint] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    StateLines: list[PersistableStateLine] = []
+    StatePoints: list[PersistableStatePoint] = []
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -356,8 +355,8 @@ class State(DStabilitySubStructure):
 
     def add_state_line(
         self,
-        points: List[PersistablePoint],
-        state_points: List[PersistableStateLinePoint],
+        points: list[PersistablePoint],
+        state_points: list[PersistableStateLinePoint],
     ) -> PersistableStateLine:
         state_line = PersistableStateLine(Points=points, Values=state_points)
         self.StateLines.append(PersistableStateLine(Points=points, Values=state_points))
@@ -365,7 +364,7 @@ class State(DStabilitySubStructure):
 
     def get_state(
         self, state_id: int
-    ) -> Union[PersistableStatePoint, PersistableStateLine]:
+    ) -> PersistableStatePoint | PersistableStateLine:
         for state in self.StatePoints + self.StateLines:
             if state.Id == str(state_id):
                 return state
@@ -377,8 +376,8 @@ class State(DStabilitySubStructure):
 
 
 class PersistableStateCorrelation(DStabilityBaseModelStructure):
-    CorrelatedStateIds: Optional[List[Optional[str]]] = None
-    IsFullyCorrelated: Optional[bool] = None
+    CorrelatedStateIds: list[str | None] | None = None
+    IsFullyCorrelated: bool | None = None
 
     @field_validator("CorrelatedStateIds", mode="before")
     def transform_id_to_str(cls, values) -> str:
@@ -402,9 +401,9 @@ class StateCorrelation(DStabilitySubStructure):
     def structure_group(cls) -> str:
         return "statecorrelations"
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    StateCorrelations: Optional[List[Optional[PersistableStateCorrelation]]] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    StateCorrelations: list[PersistableStateCorrelation | None] | None = []
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -429,18 +428,18 @@ class Stage(DStabilitySubStructure):
     def structure_group(cls) -> str:
         return "stages"
 
-    DecorationsId: Optional[str] = None
-    GeometryId: Optional[str] = None
-    Id: Optional[str] = None
-    Label: Optional[str] = ""
-    LoadsId: Optional[str] = None
-    Notes: Optional[str] = ""
-    ReinforcementsId: Optional[str] = None
-    SoilLayersId: Optional[str] = None
-    StateCorrelationsId: Optional[str] = None
-    StateId: Optional[str] = None
-    WaternetCreatorSettingsId: Optional[str] = None
-    WaternetId: Optional[str] = None
+    DecorationsId: str | None = None
+    GeometryId: str | None = None
+    Id: str | None = None
+    Label: str | None = ""
+    LoadsId: str | None = None
+    Notes: str | None = ""
+    ReinforcementsId: str | None = None
+    SoilLayersId: str | None = None
+    StateCorrelationsId: str | None = None
+    StateId: str | None = None
+    WaternetCreatorSettingsId: str | None = None
+    WaternetId: str | None = None
 
     @field_validator(
         "DecorationsId",
@@ -460,11 +459,11 @@ class Stage(DStabilitySubStructure):
 
 
 class PersistableCalculation(DStabilityBaseModelStructure):
-    Id: Optional[str] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    ResultId: Optional[str] = None
-    CalculationSettingsId: Optional[str] = None
+    Id: str | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    ResultId: str | None = None
+    CalculationSettingsId: str | None = None
 
     @field_validator("Id", "ResultId", "CalculationSettingsId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -484,12 +483,12 @@ class Scenario(DStabilitySubStructure):
     def structure_group(cls) -> str:
         return "scenarios"
 
-    Stages: Optional[List[Stage]] = []
-    Calculations: Optional[List[PersistableCalculation]] = []
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
+    Stages: list[Stage] | None = []
+    Calculations: list[PersistableCalculation] | None = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -513,9 +512,9 @@ class PersistableShadingTypeEnum(Enum):
 
 
 class PersistableSoilVisualization(DStabilityBaseModelStructure):
-    Color: Optional[str] = None
-    PersistableShadingType: Optional[PersistableShadingTypeEnum]
-    SoilId: Optional[str] = None
+    Color: str | None = None
+    PersistableShadingType: PersistableShadingTypeEnum | None
+    SoilId: str | None = None
 
     @field_validator("SoilId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -525,8 +524,8 @@ class PersistableSoilVisualization(DStabilityBaseModelStructure):
 
 
 class SoilVisualisation(DStabilityBaseModelStructure):
-    ContentVersion: Optional[str] = "2"
-    SoilVisualizations: Optional[List[Optional[PersistableSoilVisualization]]] = []
+    ContentVersion: str | None = "2"
+    SoilVisualizations: list[PersistableSoilVisualization | None] | None = []
 
     @classmethod
     def structure_name(cls) -> str:
@@ -534,8 +533,8 @@ class SoilVisualisation(DStabilityBaseModelStructure):
 
 
 class PersistableSoilLayer(DStabilityBaseModelStructure):
-    LayerId: Optional[str] = None
-    SoilId: Optional[str] = None
+    LayerId: str | None = None
+    SoilId: str | None = None
 
     @field_validator("LayerId", "SoilId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -555,9 +554,9 @@ class SoilLayerCollection(DStabilitySubStructure):
     def structure_group(cls) -> str:
         return "soillayers"
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    SoilLayers: List[PersistableSoilLayer] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    SoilLayers: list[PersistableSoilLayer] = []
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -570,7 +569,7 @@ class SoilLayerCollection(DStabilitySubStructure):
         self.SoilLayers.append(psl)
         return psl
 
-    def get_ids(self, exclude_soil_layer_id: Optional[int]) -> Set[str]:
+    def get_ids(self, exclude_soil_layer_id: int | None) -> set[str]:
         if exclude_soil_layer_id is not None:
             exclude_soil_layer_id = str(exclude_soil_layer_id)
         return {
@@ -581,7 +580,7 @@ class SoilLayerCollection(DStabilitySubStructure):
 
 
 class PersistableSoilCorrelation(DStabilityBaseModelStructure):
-    CorrelatedSoilIds: Optional[List[str]] = None
+    CorrelatedSoilIds: list[str] | None = None
 
     @field_validator("CorrelatedSoilIds", mode="before")
     def transform_id_to_str(cls, values) -> str:
@@ -597,19 +596,19 @@ class PersistableSoilCorrelation(DStabilityBaseModelStructure):
 class SoilCorrelation(DStabilitySubStructure):
     """soilcorrelations.json"""
 
-    ContentVersion: Optional[str] = "2"
-    SoilCorrelations: Optional[List[Optional[PersistableSoilCorrelation]]] = []
+    ContentVersion: str | None = "2"
+    SoilCorrelations: list[PersistableSoilCorrelation | None] | None = []
 
     @classmethod
     def structure_name(cls) -> str:
         return "soilcorrelations"
 
-    def add_soil_correlation(self, list_correlated_soil_ids: List[str]):
+    def add_soil_correlation(self, list_correlated_soil_ids: list[str]):
         """
         Add a new soil correlation to the model.
 
         Args:
-            list_correlated_soil_ids (List[str]): a list of soil ids that are correlated
+            list_correlated_soil_ids (list[str]): a list of soil ids that are correlated
 
         Returns:
             None
@@ -654,7 +653,7 @@ class PersistableSuTable(DStabilityBaseModelStructure):
     StrengthIncreaseExponentStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
-    SuTablePoints: List[PersistableSuTablePoint] = []
+    SuTablePoints: list[PersistableSuTablePoint] = []
     IsSuTableProbabilistic: bool = False
     SuTableVariationCoefficient: float = 0.0
 
@@ -675,7 +674,7 @@ class PersistableSigmaTauTablePoint(DStabilitySubStructure):
 
 
 class PersistableSigmaTauTable(DStabilityBaseModelStructure):
-    SigmaTauTablePoints: List[PersistableSigmaTauTablePoint] = []
+    SigmaTauTablePoints: list[PersistableSigmaTauTablePoint] = []
     IsSigmaTauTableProbabilistic: bool = False
     SigmaTauTableVariationCoefficient: float = 0.0
 
@@ -694,40 +693,40 @@ class PersistableSigmaTauTable(DStabilityBaseModelStructure):
 
 
 class PersistableMohrCoulombClassicShearStrengthModel(DStabilityBaseModelStructure):
-    Cohesion: Optional[float] = 0.0
+    Cohesion: float | None = 0.0
     CohesionAndFrictionAngleCorrelated: bool = False
     CohesionStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
-    FrictionAngle: Optional[float] = 0.0
+    FrictionAngle: float | None = 0.0
     FrictionAngleStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
 
 
 class PersistableMohrCoulombAdvancedShearStrengthModel(DStabilityBaseModelStructure):
-    Cohesion: Optional[float] = 0.0
+    Cohesion: float | None = 0.0
     CohesionAndFrictionAngleCorrelated: bool = False
     CohesionStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
-    Dilatancy: Optional[float] = 0.0
+    Dilatancy: float | None = 0.0
     DilatancyStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
-    FrictionAngle: Optional[float] = 0.0
+    FrictionAngle: float | None = 0.0
     FrictionAngleStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
 
 
 class PersistableSuShearStrengthModel(DStabilityBaseModelStructure):
-    ShearStrengthRatio: Optional[float] = 0.0
+    ShearStrengthRatio: float | None = 0.0
     ShearStrengthRatioAndShearStrengthExponentCorrelated: bool = False
     ShearStrengthRatioStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
-    StrengthIncreaseExponent: Optional[float] = 1.0
+    StrengthIncreaseExponent: float | None = 1.0
     StrengthIncreaseExponentStochasticParameter: PersistableStochasticParameter = (
         PersistableStochasticParameter()
     )
@@ -737,8 +736,8 @@ class PersistableSoil(DStabilityBaseModelStructure):
     Code: str = ""
     Id: str = ""
     IsProbabilistic: bool = False
-    Name: Optional[str] = ""
-    Notes: Optional[str] = ""
+    Name: str | None = ""
+    Notes: str | None = ""
     ShearStrengthModelTypeAbovePhreaticLevel: (
         ShearStrengthModelTypePhreaticLevelInternal
     ) = ShearStrengthModelTypePhreaticLevelInternal.MOHR_COULOMB_ADVANCED
@@ -769,8 +768,8 @@ class PersistableSoil(DStabilityBaseModelStructure):
 class SoilCollection(DStabilitySubStructure):
     """soils.json"""
 
-    ContentVersion: Optional[str] = "2"
-    Soils: List[PersistableSoil] = [
+    ContentVersion: str | None = "2"
+    Soils: list[PersistableSoil] = [
         PersistableSoil(
             Id="2",
             Name="Embankment new",
@@ -1131,55 +1130,55 @@ class SoilCollection(DStabilitySubStructure):
 
 
 class PersistableForbiddenLine(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    End: Optional[PersistablePoint] = None
-    Start: Optional[PersistablePoint] = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    End: PersistablePoint | None = None
+    Start: PersistablePoint | None = None
 
 
 class PersistableGeotextile(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    End: Optional[PersistablePoint] = None
-    ReductionArea: Optional[Union[float, str]] = "NaN"
-    Start: Optional[PersistablePoint] = None
-    TensileStrength: Optional[Union[float, str]] = "NaN"
+    Label: str | None = ""
+    Notes: str | None = ""
+    End: PersistablePoint | None = None
+    ReductionArea: float | str | None = "NaN"
+    Start: PersistablePoint | None = None
+    TensileStrength: float | str | None = "NaN"
 
 
 class PersistableStressAtDistance(DStabilityBaseModelStructure):
-    Distance: Optional[Union[float, str]] = "NaN"
-    Stress: Optional[Union[float, str]] = "NaN"
+    Distance: float | str | None = "NaN"
+    Stress: float | str | None = "NaN"
 
 
 class PersistableNail(DStabilityBaseModelStructure):
-    BendingStiffness: Optional[float] = 0.0
-    CriticalAngle: Optional[float] = 0.0
-    Diameter: Optional[Union[float, str]] = "NaN"
-    Direction: Optional[float] = 0.0
-    GroutDiameter: Optional[float] = 0.0
-    HorizontalSpacing: Optional[float] = 0.0
-    Label: Optional[str] = ""
-    LateralStresses: Optional[List[Optional[PersistableStressAtDistance]]] = []
-    Length: Optional[Union[float, str]] = "NaN"
-    Location: Optional[PersistablePoint] = None
-    MaxPullForce: Optional[float] = 0.0
-    Key: Optional[int] = 1
-    Notes: Optional[str] = ""
-    PlasticMoment: Optional[float] = 0.0
-    ShearStresses: Optional[List[Optional[PersistableStressAtDistance]]] = []
-    UseFacing: Optional[bool] = False
-    UseLateralStress: Optional[bool] = False
-    UseShearStress: Optional[bool] = False
+    BendingStiffness: float | None = 0.0
+    CriticalAngle: float | None = 0.0
+    Diameter: float | str | None = "NaN"
+    Direction: float | None = 0.0
+    GroutDiameter: float | None = 0.0
+    HorizontalSpacing: float | None = 0.0
+    Label: str | None = ""
+    LateralStresses: list[PersistableStressAtDistance | None] | None = []
+    Length: float | str | None = "NaN"
+    Location: PersistablePoint | None = None
+    MaxPullForce: float | None = 0.0
+    Key: int | None = 1
+    Notes: str | None = ""
+    PlasticMoment: float | None = 0.0
+    ShearStresses: list[PersistableStressAtDistance | None] | None = []
+    UseFacing: bool | None = False
+    UseLateralStress: bool | None = False
+    UseShearStress: bool | None = False
 
 
 class Reinforcements(DStabilitySubStructure):
     """reinforcements/reinforcements_x.json"""
 
-    Id: Optional[str] = None
-    ContentVersion: Optional[str] = "2"
-    ForbiddenLines: List[PersistableForbiddenLine] = []
-    Geotextiles: List[PersistableGeotextile] = []
-    Nails: List[PersistableNail] = []
+    Id: str | None = None
+    ContentVersion: str | None = "2"
+    ForbiddenLines: list[PersistableForbiddenLine] = []
+    Geotextiles: list[PersistableGeotextile] = []
+    Nails: list[PersistableNail] = []
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1189,7 +1188,7 @@ class Reinforcements(DStabilitySubStructure):
 
     def add_reinforcement(
         self, reinforcement: "DStabilityReinforcement"
-    ) -> Union[PersistableForbiddenLine, PersistableGeotextile, PersistableNail]:
+    ) -> PersistableForbiddenLine | PersistableGeotextile | PersistableNail:
         internal_datastructure = reinforcement._to_internal_datastructure()
         plural_class_name = f"{reinforcement.__class__.__name__}s"
         getattr(self, plural_class_name).append(internal_datastructure)
@@ -1199,22 +1198,22 @@ class Reinforcements(DStabilitySubStructure):
 class ProjectInfo(DStabilitySubStructure):
     """projectinfo.json."""
 
-    Analyst: Optional[str] = ""
-    ApplicationCreated: Optional[str] = ""
-    ApplicationModified: Optional[str] = ""
-    ContentVersion: Optional[str] = "2"
-    Created: Optional[date] = datetime.now().date()
-    CrossSection: Optional[str] = ""
-    Date: Optional[date] = datetime.now().date()
-    IsDataValidated: Optional[bool] = False
-    LastModified: Optional[date] = datetime.now().date()
-    LastModifier: Optional[str] = "GEOLib"
-    Path: Optional[str] = ""
-    Project: Optional[str] = ""
-    Remarks: Optional[str] = f"Created with GEOLib {version}"
+    Analyst: str | None = ""
+    ApplicationCreated: str | None = ""
+    ApplicationModified: str | None = ""
+    ContentVersion: str | None = "2"
+    Created: date | None = datetime.now().date()
+    CrossSection: str | None = ""
+    Date: date | None = datetime.now().date()
+    IsDataValidated: bool | None = False
+    LastModified: date | None = datetime.now().date()
+    LastModifier: str | None = "GEOLib"
+    Path: str | None = ""
+    Project: str | None = ""
+    Remarks: str | None = f"Created with GEOLib {version}"
 
     @classmethod
-    def nltime(cls, date: Union[date, str]) -> date:
+    def nltime(cls, date: date | str) -> date:
         if isinstance(date, str):
             position = date.index(max(date.split("-"), key=len))
             if position > 0:
@@ -1229,16 +1228,16 @@ class ProjectInfo(DStabilitySubStructure):
 
 
 class PersistableBondStress(DStabilityBaseModelStructure):
-    Sigma: Optional[Union[float, str]] = "NaN"
-    Tau: Optional[Union[float, str]] = "NaN"
+    Sigma: float | str | None = "NaN"
+    Tau: float | str | None = "NaN"
 
 
 class PersistableNailPropertiesForSoil(DStabilityBaseModelStructure):
-    AreBondStressesActive: Optional[bool] = False
-    BondStresses: Optional[List[Optional[PersistableBondStress]]] = []
-    CompressionRatio: Optional[Union[float, str]] = "NaN"
-    RheologicalCoefficient: Optional[Union[float, str]] = "NaN"
-    SoilId: Optional[str] = None
+    AreBondStressesActive: bool | None = False
+    BondStresses: list[PersistableBondStress | None] | None = []
+    CompressionRatio: float | str | None = "NaN"
+    RheologicalCoefficient: float | str | None = "NaN"
+    SoilId: str | None = None
 
     @field_validator("SoilId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1250,8 +1249,8 @@ class PersistableNailPropertiesForSoil(DStabilityBaseModelStructure):
 class NailProperties(DStabilitySubStructure):
     """nailpropertiesforsoils.json"""
 
-    ContentVersion: Optional[str] = "2"
-    NailPropertiesForSoils: Optional[List[Optional[PersistableNailPropertiesForSoil]]] = (
+    ContentVersion: str | None = "2"
+    NailPropertiesForSoils: list[PersistableNailPropertiesForSoil | None] | None = (
         []
     )
 
@@ -1261,8 +1260,8 @@ class NailProperties(DStabilitySubStructure):
 
 
 class PersistableConsolidation(DStabilityBaseModelStructure):
-    Degree: Optional[Union[float, str]] = "NaN"
-    LayerId: Optional[str] = None
+    Degree: float | str | None = "NaN"
+    LayerId: str | None = None
 
     @field_validator("LayerId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1272,18 +1271,18 @@ class PersistableConsolidation(DStabilityBaseModelStructure):
 
 
 class PersistableEarthquake(DStabilityBaseModelStructure):
-    Consolidations: Optional[List[Optional[PersistableConsolidation]]] = []
-    FreeWaterFactor: Optional[float] = 0.0
-    HorizontalFactor: Optional[float] = 0.0
-    IsEnabled: Optional[bool] = False
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    VerticalFactor: Optional[float] = 0.0
+    Consolidations: list[PersistableConsolidation | None] | None = []
+    FreeWaterFactor: float | None = 0.0
+    HorizontalFactor: float | None = 0.0
+    IsEnabled: bool | None = False
+    Label: str | None = ""
+    Notes: str | None = ""
+    VerticalFactor: float | None = 0.0
 
 
 class PersistableLayerLoad(DStabilityBaseModelStructure):
-    Consolidations: Optional[List[Optional[PersistableConsolidation]]] = []
-    LayerId: Optional[str] = None
+    Consolidations: list[PersistableConsolidation | None] | None = []
+    LayerId: str | None = None
 
     @field_validator("LayerId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1293,47 +1292,47 @@ class PersistableLayerLoad(DStabilityBaseModelStructure):
 
 
 class PersistableLineLoad(DStabilityBaseModelStructure):
-    Angle: Optional[Union[float, str]] = "NaN"
-    Consolidations: Optional[List[Optional[PersistableConsolidation]]] = []
-    Label: Optional[str] = ""
-    Location: Optional[PersistablePoint] = None
-    Magnitude: Optional[Union[float, str]] = "NaN"
-    Notes: Optional[str] = ""
-    Spread: Optional[Union[float, str]] = "NaN"
+    Angle: float | str | None = "NaN"
+    Consolidations: list[PersistableConsolidation | None] | None = []
+    Label: str | None = ""
+    Location: PersistablePoint | None = None
+    Magnitude: float | str | None = "NaN"
+    Notes: str | None = ""
+    Spread: float | str | None = "NaN"
 
 
 class PersistableTree(DStabilityBaseModelStructure):
-    Force: Optional[Union[float, str]] = "NaN"
-    Label: Optional[str] = ""
-    Location: Optional[PersistablePoint] = None
-    Notes: Optional[str] = ""
-    RootZoneWidth: Optional[Union[float, str]] = "NaN"
-    Spread: Optional[Union[float, str]] = "NaN"
+    Force: float | str | None = "NaN"
+    Label: str | None = ""
+    Location: PersistablePoint | None = None
+    Notes: str | None = ""
+    RootZoneWidth: float | str | None = "NaN"
+    Spread: float | str | None = "NaN"
 
 
 class PersistableUniformLoad(DStabilityBaseModelStructure):
-    Consolidations: Optional[List[Optional[PersistableConsolidation]]] = []
-    End: Optional[Union[float, str]] = "NaN"
-    Label: Optional[str] = ""
-    Magnitude: Optional[Union[float, str]] = "NaN"
-    Notes: Optional[str] = ""
-    Spread: Optional[Union[float, str]] = "NaN"
-    Start: Optional[Union[float, str]] = "NaN"
+    Consolidations: list[PersistableConsolidation | None] | None = []
+    End: float | str | None = "NaN"
+    Label: str | None = ""
+    Magnitude: float | str | None = "NaN"
+    Notes: str | None = ""
+    Spread: float | str | None = "NaN"
+    Start: float | str | None = "NaN"
 
 
-Load = Union[PersistableUniformLoad, PersistableLineLoad, PersistableLayerLoad]
+Load = PersistableUniformLoad | PersistableLineLoad | PersistableLayerLoad
 
 
 class Loads(DStabilitySubStructure):
     """loads/loads_x.json"""
 
-    Id: Optional[str] = None
-    ContentVersion: Optional[str] = "2"
-    Earthquake: Optional[PersistableEarthquake] = PersistableEarthquake()
-    LayerLoads: Optional[List[Optional[PersistableLayerLoad]]] = []
-    LineLoads: Optional[List[Optional[PersistableLineLoad]]] = []
-    Trees: Optional[List[Optional[PersistableTree]]] = []
-    UniformLoads: Optional[List[Optional[PersistableUniformLoad]]] = []
+    Id: str | None = None
+    ContentVersion: str | None = "2"
+    Earthquake: PersistableEarthquake | None = PersistableEarthquake()
+    LayerLoads: list[PersistableLayerLoad | None] | None = []
+    LineLoads: list[PersistableLineLoad | None] | None = []
+    Trees: list[PersistableTree | None] | None = []
+    UniformLoads: list[PersistableUniformLoad | None] | None = []
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1342,10 +1341,8 @@ class Loads(DStabilitySubStructure):
         return str(value)
 
     def add_load(
-        self, load: "DStabilityLoad", consolidations: List["Consolidation"]
-    ) -> Union[
-        PersistableUniformLoad, PersistableLineLoad, PersistableLayerLoad, PersistableTree
-    ]:
+        self, load: "DStabilityLoad", consolidations: list["Consolidation"]
+    ) -> PersistableUniformLoad | PersistableLineLoad | PersistableLayerLoad | PersistableTree:
         internal_datastructure = load.to_internal_datastructure()
 
         # Add consolidations if the load supports it
@@ -1366,7 +1363,7 @@ class Loads(DStabilitySubStructure):
         return internal_datastructure
 
     def add_layer_load(
-        self, soil_layer_id: int, consolidations: List["Consolidation"]
+        self, soil_layer_id: int, consolidations: list["Consolidation"]
     ) -> PersistableLayerLoad:
         layer_load = PersistableLayerLoad(
             LayerId=str(soil_layer_id),
@@ -1377,10 +1374,10 @@ class Loads(DStabilitySubStructure):
 
 
 class PersistableLayer(DStabilityBaseModelStructure):
-    Id: Optional[str] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    Points: Annotated[List[PersistablePoint], Field(min_length=3)]
+    Id: str | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    Points: Annotated[list[PersistablePoint], Field(min_length=3)]
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1411,9 +1408,9 @@ class Geometry(DStabilitySubStructure):
     def structure_group(cls) -> str:
         return "geometries"
 
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = None
-    Layers: List[PersistableLayer] = []
+    ContentVersion: str | None = "2"
+    Id: str | None = None
+    Layers: list[PersistableLayer] = []
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1449,7 +1446,7 @@ class Geometry(DStabilitySubStructure):
         raise ValueError(f"Layer id {id} not found in this geometry")
 
     def add_layer(
-        self, id: str, label: str, notes: str, points: List[Point]
+        self, id: str, label: str, notes: str, points: list[Point]
     ) -> PersistableLayer:
         """
         Add a new layer to the model. Layers are expected;
@@ -1461,7 +1458,7 @@ class Geometry(DStabilitySubStructure):
             id (str): id of the layer
             label (str): label of the layer
             notes (str): notes for the layers
-            points (List[Points]): list of Point classes
+            points (list[Points]): list of Point classes
 
         Returns:
             PersistableLayer: the layer as a persistable object
@@ -1478,10 +1475,10 @@ class Geometry(DStabilitySubStructure):
 
 
 class PersistableElevation(DStabilityBaseModelStructure):
-    AddedLayerId: Optional[str] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    Points: Optional[List[Optional[PersistablePoint]]] = None
+    AddedLayerId: str | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    Points: list[PersistablePoint | None] | None = None
 
     @field_validator("AddedLayerId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1491,18 +1488,18 @@ class PersistableElevation(DStabilityBaseModelStructure):
 
 
 class PersistableExcavation(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    Points: Optional[List[Optional[PersistablePoint]]] = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    Points: list[PersistablePoint | None] | None = None
 
 
 class Decorations(DStabilitySubStructure):
     """decorations/decorations_x.json."""
 
-    Elevations: Optional[List[Optional[PersistableElevation]]] = []
-    ContentVersion: Optional[str] = "2"
-    Excavations: Optional[List[Optional[PersistableExcavation]]] = []
-    Id: Optional[str] = None
+    Elevations: list[PersistableElevation | None] | None = []
+    ContentVersion: str | None = "2"
+    Excavations: list[PersistableExcavation | None] | None = []
+    Id: str | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1518,63 +1515,63 @@ class Decorations(DStabilitySubStructure):
 
 
 class PersistableCircle(DStabilityBaseModelStructure):
-    Center: Optional[PersistablePoint] = PersistablePoint()
-    Radius: Optional[Union[float, str]] = "NaN"
+    Center: PersistablePoint | None = PersistablePoint()
+    Radius: float | str | None = "NaN"
 
 
 class PersistableBishopSettings(DStabilityBaseModelStructure):
-    Circle: Optional[PersistableCircle] = PersistableCircle()
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
+    Circle: PersistableCircle | None = PersistableCircle()
+    Label: str | None = ""
+    Notes: str | None = ""
 
 
 class PersistableGridEnhancements(DStabilityBaseModelStructure):
-    ExtrapolateSearchSpace: Optional[bool] = True
+    ExtrapolateSearchSpace: bool | None = True
 
 
 class NullablePersistablePoint(DStabilityBaseModelStructure):
-    X: Optional[Union[float, str]] = "NaN"
-    Z: Optional[Union[float, str]] = "NaN"
+    X: float | str | None = "NaN"
+    Z: float | str | None = "NaN"
 
 
 class PersistableSearchGrid(DStabilityBaseModelStructure):
-    BottomLeft: Optional[NullablePersistablePoint] = None
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    NumberOfPointsInX: Optional[int] = 1
-    NumberOfPointsInZ: Optional[int] = 1
-    Space: Optional[float] = 1.0
+    BottomLeft: NullablePersistablePoint | None = None
+    Label: str | None = ""
+    Notes: str | None = ""
+    NumberOfPointsInX: int | None = 1
+    NumberOfPointsInZ: int | None = 1
+    Space: float | None = 1.0
 
 
 class PersistableSlipPlaneConstraints(DStabilityBaseModelStructure):
-    IsSizeConstraintsEnabled: Optional[bool] = False
-    IsZoneAConstraintsEnabled: Optional[bool] = False
-    IsZoneBConstraintsEnabled: Optional[bool] = False
-    MinimumSlipPlaneDepth: Optional[float] = 0.0
-    MinimumSlipPlaneLength: Optional[float] = 0.0
-    WidthZoneA: Optional[float] = 0.0
-    WidthZoneB: Optional[float] = 0.0
-    XLeftZoneA: Optional[float] = 0.0
-    XLeftZoneB: Optional[float] = 0.0
+    IsSizeConstraintsEnabled: bool | None = False
+    IsZoneAConstraintsEnabled: bool | None = False
+    IsZoneBConstraintsEnabled: bool | None = False
+    MinimumSlipPlaneDepth: float | None = 0.0
+    MinimumSlipPlaneLength: float | None = 0.0
+    WidthZoneA: float | None = 0.0
+    WidthZoneB: float | None = 0.0
+    XLeftZoneA: float | None = 0.0
+    XLeftZoneB: float | None = 0.0
 
 
 class PersistableTangentLines(DStabilityBaseModelStructure):
-    BottomTangentLineZ: Optional[Union[float, str]] = "NaN"
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    NumberOfTangentLines: Optional[int] = 1
-    Space: Optional[float] = 0.5
+    BottomTangentLineZ: float | str | None = "NaN"
+    Label: str | None = ""
+    Notes: str | None = ""
+    NumberOfTangentLines: int | None = 1
+    Space: float | None = 0.5
 
 
 class PersistableBishopBruteForceSettings(DStabilityBaseModelStructure):
-    GridEnhancements: Optional[PersistableGridEnhancements] = (
+    GridEnhancements: PersistableGridEnhancements | None = (
         PersistableGridEnhancements()
     )
-    SearchGrid: Optional[PersistableSearchGrid] = PersistableSearchGrid()
-    SlipPlaneConstraints: Optional[PersistableSlipPlaneConstraints] = (
+    SearchGrid: PersistableSearchGrid | None = PersistableSearchGrid()
+    SlipPlaneConstraints: PersistableSlipPlaneConstraints | None = (
         PersistableSlipPlaneConstraints()
     )
-    TangentLines: Optional[PersistableTangentLines] = PersistableTangentLines()
+    TangentLines: PersistableTangentLines | None = PersistableTangentLines()
 
 
 class CalculationTypeEnum(Enum):
@@ -1588,16 +1585,16 @@ CalculationType = CalculationTypeEnum
 
 
 class PersistableGeneticSlipPlaneConstraints(DStabilityBaseModelStructure):
-    IsEnabled: Optional[bool] = False
-    MinimumAngleBetweenSlices: Optional[float] = 0.0
-    MinimumThrustLinePercentageInsideSlices: Optional[float] = 0.0
+    IsEnabled: bool | None = False
+    MinimumAngleBetweenSlices: float | None = 0.0
+    MinimumThrustLinePercentageInsideSlices: float | None = 0.0
 
 
 class PersistableSpencerSettings(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    SlipPlane: Optional[List[Optional[PersistablePoint]]] = None
-    SlipPlaneConstraints: Optional[PersistableGeneticSlipPlaneConstraints] = (
+    Label: str | None = ""
+    Notes: str | None = ""
+    SlipPlane: list[PersistablePoint | None] | None = None
+    SlipPlaneConstraints: PersistableGeneticSlipPlaneConstraints | None = (
         PersistableGeneticSlipPlaneConstraints()
     )
 
@@ -1611,76 +1608,76 @@ OptionsType = OptionsTypeEnum
 
 
 class PersistableSpencerGeneticSettings(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    OptionsType: Optional[OptionsTypeEnum] = OptionsType.DEFAULT
-    SlipPlaneA: Optional[List[Optional[PersistablePoint]]] = None
-    SlipPlaneB: Optional[List[Optional[PersistablePoint]]] = None
-    SlipPlaneConstraints: Optional[PersistableGeneticSlipPlaneConstraints] = (
+    Label: str | None = ""
+    Notes: str | None = ""
+    OptionsType: OptionsTypeEnum | None = OptionsType.DEFAULT
+    SlipPlaneA: list[PersistablePoint | None] | None = None
+    SlipPlaneB: list[PersistablePoint | None] | None = None
+    SlipPlaneConstraints: PersistableGeneticSlipPlaneConstraints | None = (
         PersistableGeneticSlipPlaneConstraints()
     )
 
 
 class PersistableTwoCirclesOnTangentLine(DStabilityBaseModelStructure):
-    FirstCircleCenter: Optional[NullablePersistablePoint] = NullablePersistablePoint()
-    FirstCircleRadius: Optional[Union[float, str]] = "NaN"
-    SecondCircleCenter: Optional[NullablePersistablePoint] = NullablePersistablePoint()
+    FirstCircleCenter: NullablePersistablePoint | None = NullablePersistablePoint()
+    FirstCircleRadius: float | str | None = "NaN"
+    SecondCircleCenter: NullablePersistablePoint | None = NullablePersistablePoint()
 
 
 class PersistableUpliftVanSettings(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    SlipPlane: Optional[PersistableTwoCirclesOnTangentLine] = (
+    Label: str | None = ""
+    Notes: str | None = ""
+    SlipPlane: PersistableTwoCirclesOnTangentLine | None = (
         PersistableTwoCirclesOnTangentLine()
     )
 
 
 class PersistableSearchArea(DStabilityBaseModelStructure):
-    Height: Optional[float] = 0.0
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    TopLeft: Optional[NullablePersistablePoint] = None
-    Width: Optional[float] = 0.0
+    Height: float | None = 0.0
+    Label: str | None = ""
+    Notes: str | None = ""
+    TopLeft: NullablePersistablePoint | None = None
+    Width: float | None = 0.0
 
 
 class PersistableTangentArea(DStabilityBaseModelStructure):
-    Height: Optional[float] = 0.0
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    TopZ: Optional[Union[float, str]] = "NaN"
+    Height: float | None = 0.0
+    Label: str | None = ""
+    Notes: str | None = ""
+    TopZ: float | str | None = "NaN"
 
 
 class PersistableUpliftVanParticleSwarmSettings(DStabilityBaseModelStructure):
-    Label: Optional[str] = ""
-    Notes: Optional[str] = ""
-    OptionsType: Optional[OptionsTypeEnum] = OptionsType.DEFAULT
-    SearchAreaA: Optional[PersistableSearchArea] = PersistableSearchArea()
-    SearchAreaB: Optional[PersistableSearchArea] = PersistableSearchArea()
-    SlipPlaneConstraints: Optional[PersistableSlipPlaneConstraints] = (
+    Label: str | None = ""
+    Notes: str | None = ""
+    OptionsType: OptionsTypeEnum | None = OptionsType.DEFAULT
+    SearchAreaA: PersistableSearchArea | None = PersistableSearchArea()
+    SearchAreaB: PersistableSearchArea | None = PersistableSearchArea()
+    SlipPlaneConstraints: PersistableSlipPlaneConstraints | None = (
         PersistableSlipPlaneConstraints()
     )
-    TangentArea: Optional[PersistableTangentArea] = PersistableTangentArea()
+    TangentArea: PersistableTangentArea | None = PersistableTangentArea()
 
 
 class CalculationSettings(DStabilitySubStructure):
     """calculationsettings/calculationsettings_x.json"""
 
-    AnalysisType: Optional[AnalysisTypeEnum] = AnalysisTypeEnum.BISHOP_BRUTE_FORCE
-    Bishop: Optional[PersistableBishopSettings] = PersistableBishopSettings()
-    BishopBruteForce: Optional[PersistableBishopBruteForceSettings] = (
+    AnalysisType: AnalysisTypeEnum | None = AnalysisTypeEnum.BISHOP_BRUTE_FORCE
+    Bishop: PersistableBishopSettings | None = PersistableBishopSettings()
+    BishopBruteForce: PersistableBishopBruteForceSettings | None = (
         PersistableBishopBruteForceSettings()
     )
-    CalculationType: Optional[CalculationTypeEnum] = CalculationTypeEnum.DETERMINISTIC
-    ContentVersion: Optional[str] = "2"
-    Id: Optional[str] = "19"
-    ModelFactorMean: Optional[float] = 1.05
-    ModelFactorStandardDeviation: Optional[float] = 0.033
-    Spencer: Optional[PersistableSpencerSettings] = PersistableSpencerSettings()
-    SpencerGenetic: Optional[PersistableSpencerGeneticSettings] = (
+    CalculationType: CalculationTypeEnum | None = CalculationTypeEnum.DETERMINISTIC
+    ContentVersion: str | None = "2"
+    Id: str | None = "19"
+    ModelFactorMean: float | None = 1.05
+    ModelFactorStandardDeviation: float | None = 0.033
+    Spencer: PersistableSpencerSettings | None = PersistableSpencerSettings()
+    SpencerGenetic: PersistableSpencerGeneticSettings | None = (
         PersistableSpencerGeneticSettings()
     )
-    UpliftVan: Optional[PersistableUpliftVanSettings] = PersistableUpliftVanSettings()
-    UpliftVanParticleSwarm: Optional[PersistableUpliftVanParticleSwarmSettings] = (
+    UpliftVan: PersistableUpliftVanSettings | None = PersistableUpliftVanSettings()
+    UpliftVanParticleSwarm: PersistableUpliftVanParticleSwarmSettings | None = (
         PersistableUpliftVanParticleSwarmSettings()
     )
 
@@ -1728,61 +1725,61 @@ class CalculationSettings(DStabilitySubStructure):
 
 
 class PersistableSlice(DStabilityBaseModelStructure):
-    ArcLength: Optional[Union[float, str]] = "NaN"
-    BottomAngle: Optional[Union[float, str]] = "NaN"
-    BottomLeft: Optional[PersistablePoint] = None
-    BottomRight: Optional[PersistablePoint] = None
-    CohesionInput: Optional[Union[float, str]] = "NaN"
-    CohesionOutput: Optional[Union[float, str]] = "NaN"
-    DegreeOfConsolidationLoadPorePressure: Optional[Union[float, str]] = "NaN"
-    DegreeOfConsolidationPorePressure: Optional[Union[float, str]] = "NaN"
-    DilatancyInput: Optional[Union[float, str]] = "NaN"
-    DilatancyOutput: Optional[Union[float, str]] = "NaN"
-    EffectiveStress: Optional[Union[float, str]] = "NaN"
-    HorizontalPorePressure: Optional[Union[float, str]] = "NaN"
-    HorizontalSoilQuakeStress: Optional[Union[float, str]] = "NaN"
-    HydrostaticPorePressure: Optional[Union[float, str]] = "NaN"
-    InputShearStress: Optional[Union[float, str]] = "NaN"
-    Label: Optional[str] = None
-    LoadStress: Optional[Union[float, str]] = "NaN"
-    MInput: Optional[Union[float, str]] = "NaN"
-    NormalStress: Optional[Union[float, str]] = "NaN"
-    Ocr: Optional[Union[float, str]] = "NaN"
-    OutputShearStress: Optional[Union[float, str]] = "NaN"
-    PhiInput: Optional[Union[float, str]] = "NaN"
-    PhiOutput: Optional[Union[float, str]] = "NaN"
-    PiezometricPorePressure: Optional[Union[float, str]] = "NaN"
-    Pop: Optional[Union[float, str]] = "NaN"
-    ResultantForce: Optional[Union[float, str]] = "NaN"
-    ResultantMoment: Optional[Union[float, str]] = "NaN"
-    SInput: Optional[Union[float, str]] = "NaN"
-    ShearStress: Optional[Union[float, str]] = "NaN"
-    SuInput: Optional[Union[float, str]] = "NaN"
-    SuOutput: Optional[Union[float, str]] = "NaN"
-    SurfacePorePressure: Optional[Union[float, str]] = "NaN"
-    TopAngle: Optional[Union[float, str]] = "NaN"
-    TopLeft: Optional[PersistablePoint] = None
-    TopRight: Optional[PersistablePoint] = None
-    TotalPorePressure: Optional[Union[float, str]] = "NaN"
-    TotalStress: Optional[Union[float, str]] = "NaN"
-    UpliftFactor: Optional[Union[float, str]] = "NaN"
-    VerticalPorePressure: Optional[Union[float, str]] = "NaN"
-    VerticalSoilQuakeStress: Optional[Union[float, str]] = "NaN"
-    WaterQuakeStress: Optional[Union[float, str]] = "NaN"
-    Weight: Optional[Union[float, str]] = "NaN"
-    Width: Optional[Union[float, str]] = "NaN"
-    YieldStress: Optional[Union[float, str]] = "NaN"
-    ShearStrengthModelType: Optional[ShearStrengthModelTypePhreaticLevelInternal] = None
+    ArcLength: float | str | None = "NaN"
+    BottomAngle: float | str | None = "NaN"
+    BottomLeft: PersistablePoint | None = None
+    BottomRight: PersistablePoint | None = None
+    CohesionInput: float | str | None = "NaN"
+    CohesionOutput: float | str | None = "NaN"
+    DegreeOfConsolidationLoadPorePressure: float | str | None = "NaN"
+    DegreeOfConsolidationPorePressure: float | str | None = "NaN"
+    DilatancyInput: float | str | None = "NaN"
+    DilatancyOutput: float | str | None = "NaN"
+    EffectiveStress: float | str | None = "NaN"
+    HorizontalPorePressure: float | str | None = "NaN"
+    HorizontalSoilQuakeStress: float | str | None = "NaN"
+    HydrostaticPorePressure: float | str | None = "NaN"
+    InputShearStress: float | str | None = "NaN"
+    Label: str | None = None
+    LoadStress: float | str | None = "NaN"
+    MInput: float | str | None = "NaN"
+    NormalStress: float | str | None = "NaN"
+    Ocr: float | str | None = "NaN"
+    OutputShearStress: float | str | None = "NaN"
+    PhiInput: float | str | None = "NaN"
+    PhiOutput: float | str | None = "NaN"
+    PiezometricPorePressure: float | str | None = "NaN"
+    Pop: float | str | None = "NaN"
+    ResultantForce: float | str | None = "NaN"
+    ResultantMoment: float | str | None = "NaN"
+    SInput: float | str | None = "NaN"
+    ShearStress: float | str | None = "NaN"
+    SuInput: float | str | None = "NaN"
+    SuOutput: float | str | None = "NaN"
+    SurfacePorePressure: float | str | None = "NaN"
+    TopAngle: float | str | None = "NaN"
+    TopLeft: PersistablePoint | None = None
+    TopRight: PersistablePoint | None = None
+    TotalPorePressure: float | str | None = "NaN"
+    TotalStress: float | str | None = "NaN"
+    UpliftFactor: float | str | None = "NaN"
+    VerticalPorePressure: float | str | None = "NaN"
+    VerticalSoilQuakeStress: float | str | None = "NaN"
+    WaterQuakeStress: float | str | None = "NaN"
+    Weight: float | str | None = "NaN"
+    Width: float | str | None = "NaN"
+    YieldStress: float | str | None = "NaN"
+    ShearStrengthModelType: ShearStrengthModelTypePhreaticLevelInternal | None = None
 
 
 class BishopBruteForceResult(DStabilitySubStructure):
-    Circle: Optional[PersistableCircle] = None
-    FactorOfSafety: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    Slices: Optional[List[Optional[PersistableSlice]]] = None
-    ResultThreshold: Optional[Union[float, str]] = "NaN"
-    SlipPlaneResults: Optional[list] = None
+    Circle: PersistableCircle | None = None
+    FactorOfSafety: float | str | None = "NaN"
+    Id: str | None = None
+    Points: list[PersistablePoint | None] | None = None
+    Slices: list[PersistableSlice | None] | None = None
+    ResultThreshold: float | str | None = "NaN"
+    SlipPlaneResults: list | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1807,11 +1804,11 @@ class BishopBruteForceResult(DStabilitySubStructure):
 
 
 class PersistableSoilContribution(DStabilityBaseModelStructure):
-    Alpha: Optional[Union[float, str]] = "NaN"
-    Property: Optional[str] = None
-    SoilId: Optional[str] = None
-    UncorrelatedAlpha: Optional[Union[float, str]] = "NaN"
-    Value: Optional[Union[float, str]] = "NaN"
+    Alpha: float | str | None = "NaN"
+    Property: str | None = None
+    SoilId: str | None = None
+    UncorrelatedAlpha: float | str | None = "NaN"
+    Value: float | str | None = "NaN"
 
     @field_validator("SoilId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1821,11 +1818,11 @@ class PersistableSoilContribution(DStabilityBaseModelStructure):
 
 
 class PersistableCalculationContribution(DStabilityBaseModelStructure):
-    Alpha: Optional[Union[float, str]] = "NaN"
-    Property: Optional[str] = None
-    CalculationId: Optional[str] = None
-    UncorrelatedAlpha: Optional[Union[float, str]] = "NaN"
-    Value: Optional[Union[float, str]] = "NaN"
+    Alpha: float | str | None = "NaN"
+    Property: str | None = None
+    CalculationId: str | None = None
+    UncorrelatedAlpha: float | str | None = "NaN"
+    Value: float | str | None = "NaN"
 
     @field_validator("CalculationId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1835,11 +1832,11 @@ class PersistableCalculationContribution(DStabilityBaseModelStructure):
 
 
 class PersistableStateLinePointContribution(DStabilityBaseModelStructure):
-    Alpha: Optional[Union[float, str]] = "NaN"
-    Property: Optional[str] = None
-    StateLinePointId: Optional[str] = None
-    UncorrelatedAlpha: Optional[Union[float, str]] = "NaN"
-    Value: Optional[Union[float, str]] = "NaN"
+    Alpha: float | str | None = "NaN"
+    Property: str | None = None
+    StateLinePointId: str | None = None
+    UncorrelatedAlpha: float | str | None = "NaN"
+    Value: float | str | None = "NaN"
 
     @field_validator("StateLinePointId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1849,11 +1846,11 @@ class PersistableStateLinePointContribution(DStabilityBaseModelStructure):
 
 
 class PersistableStatePointContribution(DStabilityBaseModelStructure):
-    Alpha: Optional[Union[float, str]] = "NaN"
-    Property: Optional[str] = None
-    StatePointId: Optional[str] = None
-    UncorrelatedAlpha: Optional[Union[float, str]] = "NaN"
-    Value: Optional[Union[float, str]] = "NaN"
+    Alpha: float | str | None = "NaN"
+    Property: str | None = None
+    StatePointId: str | None = None
+    UncorrelatedAlpha: float | str | None = "NaN"
+    Value: float | str | None = "NaN"
 
     @field_validator("StatePointId", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1863,22 +1860,16 @@ class PersistableStatePointContribution(DStabilityBaseModelStructure):
 
 
 class BishopReliabilityResult(DStabilitySubStructure):
-    Circle: Optional[PersistableCircle] = None
-    Converged: Optional[bool] = None
-    FailureProbability: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    ReliabilityIndex: Optional[Union[float, str]] = "NaN"
-    DistanceToConvergence: Optional[Union[float, str]] = "NaN"
-    SoilContributions: Optional[List[Optional[PersistableSoilContribution]]] = None
-    CalculationContributions: Optional[
-        List[Optional[PersistableCalculationContribution]]
-    ] = None
-    StateLinePointContributions: Optional[
-        List[Optional[PersistableStateLinePointContribution]]
-    ] = None
-    StatePointContributions: Optional[
-        List[Optional[PersistableStatePointContribution]]
-    ] = None
+    Circle: PersistableCircle | None = None
+    Converged: bool | None = None
+    FailureProbability: float | str | None = "NaN"
+    Id: str | None = None
+    ReliabilityIndex: float | str | None = "NaN"
+    DistanceToConvergence: float | str | None = "NaN"
+    SoilContributions: list[PersistableSoilContribution | None] | None = None
+    CalculationContributions: list[PersistableCalculationContribution | None] | None = None
+    StateLinePointContributions: list[PersistableStateLinePointContribution | None] | None = None
+    StatePointContributions: list[PersistableStatePointContribution | None] | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1903,24 +1894,18 @@ class BishopReliabilityResult(DStabilitySubStructure):
 
 
 class BishopBruteForceReliabilityResult(DStabilitySubStructure):
-    Circle: Optional[PersistableCircle] = None
-    Converged: Optional[bool] = None
-    FailureProbability: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    ReliabilityIndex: Optional[Union[float, str]] = "NaN"
-    DistanceToConvergence: Optional[Union[float, str]] = "NaN"
-    SoilContributions: Optional[List[Optional[PersistableSoilContribution]]] = None
-    CalculationContributions: Optional[
-        List[Optional[PersistableCalculationContribution]]
-    ] = None
-    StateLinePointContributions: Optional[
-        List[Optional[PersistableStateLinePointContribution]]
-    ] = None
-    StatePointContributions: Optional[
-        List[Optional[PersistableStatePointContribution]]
-    ] = None
-    ResultThreshold: Optional[Union[float, str]] = "NaN"
-    SlipPlaneResults: Optional[list] = None
+    Circle: PersistableCircle | None = None
+    Converged: bool | None = None
+    FailureProbability: float | str | None = "NaN"
+    Id: str | None = None
+    ReliabilityIndex: float | str | None = "NaN"
+    DistanceToConvergence: float | str | None = "NaN"
+    SoilContributions: list[PersistableSoilContribution | None] | None = None
+    CalculationContributions: list[PersistableCalculationContribution | None] | None = None
+    StateLinePointContributions: list[PersistableStateLinePointContribution | None] | None = None
+    StatePointContributions: list[PersistableStatePointContribution | None] | None = None
+    ResultThreshold: float | str | None = "NaN"
+    SlipPlaneResults: list | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1945,11 +1930,11 @@ class BishopBruteForceReliabilityResult(DStabilitySubStructure):
 
 
 class BishopResult(DStabilitySubStructure):
-    Circle: Optional[PersistableCircle] = None
-    FactorOfSafety: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    Slices: Optional[List[Optional[PersistableSlice]]] = None
+    Circle: PersistableCircle | None = None
+    FactorOfSafety: float | str | None = "NaN"
+    Id: str | None = None
+    Points: list[PersistablePoint | None] | None = None
+    Slices: list[PersistableSlice | None] | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -1974,67 +1959,67 @@ class BishopResult(DStabilitySubStructure):
 
 
 class PersistableSpencerSlice(DStabilityBaseModelStructure):
-    ArcLength: Optional[Union[float, str]] = "NaN"
-    BottomAngle: Optional[Union[float, str]] = "NaN"
-    BottomLeft: Optional[PersistablePoint] = None
-    BottomRight: Optional[PersistablePoint] = None
-    CohesionInput: Optional[Union[float, str]] = "NaN"
-    CohesionOutput: Optional[Union[float, str]] = "NaN"
-    DegreeOfConsolidationLoadPorePressure: Optional[Union[float, str]] = "NaN"
-    DegreeOfConsolidationPorePressure: Optional[Union[float, str]] = "NaN"
-    DilatancyInput: Optional[Union[float, str]] = "NaN"
-    DilatancyOutput: Optional[Union[float, str]] = "NaN"
-    EffectiveStress: Optional[Union[float, str]] = "NaN"
-    HorizontalPorePressure: Optional[Union[float, str]] = "NaN"
-    HorizontalSoilQuakeStress: Optional[Union[float, str]] = "NaN"
-    HydrostaticPorePressure: Optional[Union[float, str]] = "NaN"
-    InputShearStress: Optional[Union[float, str]] = "NaN"
-    Label: Optional[str] = None
-    LeftForce: Optional[Union[float, str]] = "NaN"
-    LeftForceAngle: Optional[Union[float, str]] = "NaN"
-    LeftForceY: Optional[Union[float, str]] = "NaN"
-    LoadStress: Optional[Union[float, str]] = "NaN"
-    MInput: Optional[Union[float, str]] = "NaN"
-    NormalStress: Optional[Union[float, str]] = "NaN"
-    Ocr: Optional[Union[float, str]] = "NaN"
-    OutputShearStress: Optional[Union[float, str]] = "NaN"
-    PhiInput: Optional[Union[float, str]] = "NaN"
-    PhiOutput: Optional[Union[float, str]] = "NaN"
-    PiezometricPorePressure: Optional[Union[float, str]] = "NaN"
-    Pop: Optional[Union[float, str]] = "NaN"
-    ResultantForce: Optional[Union[float, str]] = "NaN"
-    ResultantMoment: Optional[Union[float, str]] = "NaN"
-    RightForce: Optional[Union[float, str]] = "NaN"
-    RightForceAngle: Optional[Union[float, str]] = "NaN"
-    RightForceY: Optional[Union[float, str]] = "NaN"
-    ShearStress: Optional[Union[float, str]] = "NaN"
-    SInput: Optional[Union[float, str]] = "NaN"
-    SuInput: Optional[Union[float, str]] = "NaN"
-    SuOutput: Optional[Union[float, str]] = "NaN"
-    SurfacePorePressure: Optional[Union[float, str]] = "NaN"
-    TopAngle: Optional[Union[float, str]] = "NaN"
-    TopLeft: Optional[PersistablePoint] = None
-    TopRight: Optional[PersistablePoint] = None
-    TotalPorePressure: Optional[Union[float, str]] = "NaN"
-    TotalStress: Optional[Union[float, str]] = "NaN"
-    UpliftFactor: Optional[Union[float, str]] = "NaN"
-    VerticalPorePressure: Optional[Union[float, str]] = "NaN"
-    VerticalSoilQuakeStress: Optional[Union[float, str]] = "NaN"
-    WaterQuakeStress: Optional[Union[float, str]] = "NaN"
-    Weight: Optional[Union[float, str]] = "NaN"
-    Width: Optional[Union[float, str]] = "NaN"
-    YieldStress: Optional[Union[float, str]] = "NaN"
-    ShearStrengthModelType: Optional[ShearStrengthModelTypePhreaticLevelInternal] = None
+    ArcLength: float | str | None = "NaN"
+    BottomAngle: float | str | None = "NaN"
+    BottomLeft: PersistablePoint | None = None
+    BottomRight: PersistablePoint | None = None
+    CohesionInput: float | str | None = "NaN"
+    CohesionOutput: float | str | None = "NaN"
+    DegreeOfConsolidationLoadPorePressure: float | str | None = "NaN"
+    DegreeOfConsolidationPorePressure: float | str | None = "NaN"
+    DilatancyInput: float | str | None = "NaN"
+    DilatancyOutput: float | str | None = "NaN"
+    EffectiveStress: float | str | None = "NaN"
+    HorizontalPorePressure: float | str | None = "NaN"
+    HorizontalSoilQuakeStress: float | str | None = "NaN"
+    HydrostaticPorePressure: float | str | None = "NaN"
+    InputShearStress: float | str | None = "NaN"
+    Label: str | None = None
+    LeftForce: float | str | None = "NaN"
+    LeftForceAngle: float | str | None = "NaN"
+    LeftForceY: float | str | None = "NaN"
+    LoadStress: float | str | None = "NaN"
+    MInput: float | str | None = "NaN"
+    NormalStress: float | str | None = "NaN"
+    Ocr: float | str | None = "NaN"
+    OutputShearStress: float | str | None = "NaN"
+    PhiInput: float | str | None = "NaN"
+    PhiOutput: float | str | None = "NaN"
+    PiezometricPorePressure: float | str | None = "NaN"
+    Pop: float | str | None = "NaN"
+    ResultantForce: float | str | None = "NaN"
+    ResultantMoment: float | str | None = "NaN"
+    RightForce: float | str | None = "NaN"
+    RightForceAngle: float | str | None = "NaN"
+    RightForceY: float | str | None = "NaN"
+    ShearStress: float | str | None = "NaN"
+    SInput: float | str | None = "NaN"
+    SuInput: float | str | None = "NaN"
+    SuOutput: float | str | None = "NaN"
+    SurfacePorePressure: float | str | None = "NaN"
+    TopAngle: float | str | None = "NaN"
+    TopLeft: PersistablePoint | None = None
+    TopRight: PersistablePoint | None = None
+    TotalPorePressure: float | str | None = "NaN"
+    TotalStress: float | str | None = "NaN"
+    UpliftFactor: float | str | None = "NaN"
+    VerticalPorePressure: float | str | None = "NaN"
+    VerticalSoilQuakeStress: float | str | None = "NaN"
+    WaterQuakeStress: float | str | None = "NaN"
+    Weight: float | str | None = "NaN"
+    Width: float | str | None = "NaN"
+    YieldStress: float | str | None = "NaN"
+    ShearStrengthModelType: ShearStrengthModelTypePhreaticLevelInternal | None = None
 
 
 class SpencerGeneticAlgorithmResult(DStabilitySubStructure):
-    FactorOfSafety: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    Slices: Optional[List[Optional[PersistableSpencerSlice]]] = None
-    SlipPlane: Optional[List[Optional[PersistablePoint]]] = None
-    ResultThreshold: Optional[Union[float, str]] = "NaN"
-    SlipPlaneResults: Optional[list] = None
+    FactorOfSafety: float | str | None = "NaN"
+    Id: str | None = None
+    Points: list[PersistablePoint | None] | None = None
+    Slices: list[PersistableSpencerSlice | None] | None = None
+    SlipPlane: list[PersistablePoint | None] | None = None
+    ResultThreshold: float | str | None = "NaN"
+    SlipPlaneResults: list | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2059,22 +2044,16 @@ class SpencerGeneticAlgorithmResult(DStabilitySubStructure):
 
 
 class SpencerReliabilityResult(DStabilitySubStructure):
-    Converged: Optional[bool] = None
-    FailureProbability: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    ReliabilityIndex: Optional[Union[float, str]] = "NaN"
-    DistanceToConvergence: Optional[Union[float, str]] = "NaN"
-    SlipPlane: Optional[List[Optional[PersistablePoint]]] = None
-    SoilContributions: Optional[List[Optional[PersistableSoilContribution]]] = None
-    CalculationContributions: Optional[
-        List[Optional[PersistableCalculationContribution]]
-    ] = None
-    StateLinePointContributions: Optional[
-        List[Optional[PersistableStateLinePointContribution]]
-    ] = None
-    StatePointContributions: Optional[
-        List[Optional[PersistableStatePointContribution]]
-    ] = None
+    Converged: bool | None = None
+    FailureProbability: float | str | None = "NaN"
+    Id: str | None = None
+    ReliabilityIndex: float | str | None = "NaN"
+    DistanceToConvergence: float | str | None = "NaN"
+    SlipPlane: list[PersistablePoint | None] | None = None
+    SoilContributions: list[PersistableSoilContribution | None] | None = None
+    CalculationContributions: list[PersistableCalculationContribution | None] | None = None
+    StateLinePointContributions: list[PersistableStateLinePointContribution | None] | None = None
+    StatePointContributions: list[PersistableStatePointContribution | None] | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2099,22 +2078,16 @@ class SpencerReliabilityResult(DStabilitySubStructure):
 
 
 class SpencerGeneticAlgorithmReliabilityResult(DStabilitySubStructure):
-    Converged: Optional[bool] = None
-    FailureProbability: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    ReliabilityIndex: Optional[Union[float, str]] = "NaN"
-    DistanceToConvergence: Optional[Union[float, str]] = "NaN"
-    SlipPlane: Optional[List[Optional[PersistablePoint]]] = None
-    SoilContributions: Optional[List[Optional[PersistableSoilContribution]]] = None
-    CalculationContributions: Optional[
-        List[Optional[PersistableCalculationContribution]]
-    ] = None
-    StateLinePointContributions: Optional[
-        List[Optional[PersistableStateLinePointContribution]]
-    ] = None
-    StatePointContributions: Optional[
-        List[Optional[PersistableStatePointContribution]]
-    ] = None
+    Converged: bool | None = None
+    FailureProbability: float | str | None = "NaN"
+    Id: str | None = None
+    ReliabilityIndex: float | str | None = "NaN"
+    DistanceToConvergence: float | str | None = "NaN"
+    SlipPlane: list[PersistablePoint | None] | None = None
+    SoilContributions: list[PersistableSoilContribution | None] | None = None
+    CalculationContributions: list[PersistableCalculationContribution | None] | None = None
+    StateLinePointContributions: list[PersistableStateLinePointContribution | None] | None = None
+    StatePointContributions: list[PersistableStatePointContribution | None] | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2139,11 +2112,11 @@ class SpencerGeneticAlgorithmReliabilityResult(DStabilitySubStructure):
 
 
 class SpencerResult(DStabilitySubStructure):
-    FactorOfSafety: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    Slices: Optional[List[Optional[PersistableSpencerSlice]]] = None
-    SlipPlane: Optional[List[Optional[PersistablePoint]]] = None
+    FactorOfSafety: float | str | None = "NaN"
+    Id: str | None = None
+    Points: list[PersistablePoint | None] | None = None
+    Slices: list[PersistableSpencerSlice | None] | None = None
+    SlipPlane: list[PersistablePoint | None] | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2168,15 +2141,15 @@ class SpencerResult(DStabilitySubStructure):
 
 
 class UpliftVanParticleSwarmResult(DStabilitySubStructure):
-    FactorOfSafety: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    LeftCenter: Optional[PersistablePoint] = None
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    RightCenter: Optional[PersistablePoint] = None
-    Slices: Optional[List[Optional[PersistableSlice]]] = None
-    TangentLine: Optional[Union[float, str]] = "NaN"
-    ResultThreshold: Optional[Union[float, str]] = "NaN"
-    SlipPlaneResults: Optional[list] = None
+    FactorOfSafety: float | str | None = "NaN"
+    Id: str | None = None
+    LeftCenter: PersistablePoint | None = None
+    Points: list[PersistablePoint | None] | None = None
+    RightCenter: PersistablePoint | None = None
+    Slices: list[PersistableSlice | None] | None = None
+    TangentLine: float | str | None = "NaN"
+    ResultThreshold: float | str | None = "NaN"
+    SlipPlaneResults: list | None = None
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2205,24 +2178,18 @@ class UpliftVanParticleSwarmResult(DStabilitySubStructure):
 
 
 class UpliftVanReliabilityResult(DStabilitySubStructure):
-    Converged: Optional[bool] = None
-    FailureProbability: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    LeftCenter: Optional[PersistablePoint] = None
-    ReliabilityIndex: Optional[Union[float, str]] = "NaN"
-    DistanceToConvergence: Optional[Union[float, str]] = "NaN"
-    RightCenter: Optional[PersistablePoint] = None
-    SoilContributions: Optional[List[Optional[PersistableSoilContribution]]] = None
-    CalculationContributions: Optional[
-        List[Optional[PersistableCalculationContribution]]
-    ] = None
-    StateLinePointContributions: Optional[
-        List[Optional[PersistableStateLinePointContribution]]
-    ] = None
-    StatePointContributions: Optional[
-        List[Optional[PersistableStatePointContribution]]
-    ] = None
-    TangentLine: Optional[Union[float, str]] = "NaN"
+    Converged: bool | None = None
+    FailureProbability: float | str | None = "NaN"
+    Id: str | None = None
+    LeftCenter: PersistablePoint | None = None
+    ReliabilityIndex: float | str | None = "NaN"
+    DistanceToConvergence: float | str | None = "NaN"
+    RightCenter: PersistablePoint | None = None
+    SoilContributions: list[PersistableSoilContribution | None] | None = None
+    CalculationContributions: list[PersistableCalculationContribution | None] | None = None
+    StateLinePointContributions: list[PersistableStateLinePointContribution | None] | None = None
+    StatePointContributions: list[PersistableStatePointContribution | None] | None = None
+    TangentLine: float | str | None = "NaN"
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2251,26 +2218,20 @@ class UpliftVanReliabilityResult(DStabilitySubStructure):
 
 
 class UpliftVanParticleSwarmReliabilityResult(DStabilitySubStructure):
-    ResultThreshold: Optional[Union[float, str]] = "NaN"
-    SlipPlaneResults: Optional[list] = None
-    Converged: Optional[bool] = None
-    FailureProbability: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    LeftCenter: Optional[PersistablePoint] = None
-    ReliabilityIndex: Optional[Union[float, str]] = "NaN"
-    DistanceToConvergence: Optional[Union[float, str]] = "NaN"
-    RightCenter: Optional[PersistablePoint] = None
-    SoilContributions: Optional[List[Optional[PersistableSoilContribution]]] = None
-    CalculationContributions: Optional[
-        List[Optional[PersistableCalculationContribution]]
-    ] = None
-    StateLinePointContributions: Optional[
-        List[Optional[PersistableStateLinePointContribution]]
-    ] = None
-    StatePointContributions: Optional[
-        List[Optional[PersistableStatePointContribution]]
-    ] = None
-    TangentLine: Optional[Union[float, str]] = "NaN"
+    ResultThreshold: float | str | None = "NaN"
+    SlipPlaneResults: list | None = None
+    Converged: bool | None = None
+    FailureProbability: float | str | None = "NaN"
+    Id: str | None = None
+    LeftCenter: PersistablePoint | None = None
+    ReliabilityIndex: float | str | None = "NaN"
+    DistanceToConvergence: float | str | None = "NaN"
+    RightCenter: PersistablePoint | None = None
+    SoilContributions: list[PersistableSoilContribution | None] | None = None
+    CalculationContributions: list[PersistableCalculationContribution | None] | None = None
+    StateLinePointContributions: list[PersistableStateLinePointContribution | None] | None = None
+    StatePointContributions: list[PersistableStatePointContribution | None] | None = None
+    TangentLine: float | str | None = "NaN"
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2299,13 +2260,13 @@ class UpliftVanParticleSwarmReliabilityResult(DStabilitySubStructure):
 
 
 class UpliftVanResult(DStabilitySubStructure):
-    FactorOfSafety: Optional[Union[float, str]] = "NaN"
-    Id: Optional[str] = None
-    LeftCenter: Optional[PersistablePoint] = None
-    Points: Optional[List[Optional[PersistablePoint]]] = None
-    RightCenter: Optional[PersistablePoint] = None
-    Slices: Optional[List[Optional[PersistableSlice]]] = None
-    TangentLine: Optional[Union[float, str]] = "NaN"
+    FactorOfSafety: float | str | None = "NaN"
+    Id: str | None = None
+    LeftCenter: PersistablePoint | None = None
+    Points: list[PersistablePoint | None] | None = None
+    RightCenter: PersistablePoint | None = None
+    Slices: list[PersistableSlice | None] | None = None
+    TangentLine: float | str | None = "NaN"
 
     @field_validator("Id", mode="before")
     def transform_id_to_str(cls, value) -> str:
@@ -2333,21 +2294,21 @@ class UpliftVanResult(DStabilitySubStructure):
             )
 
 
-DStabilityResult = Union[
-    UpliftVanResult,
-    UpliftVanParticleSwarmResult,
-    UpliftVanReliabilityResult,
-    UpliftVanParticleSwarmReliabilityResult,
-    SpencerGeneticAlgorithmResult,
-    SpencerReliabilityResult,
-    SpencerGeneticAlgorithmReliabilityResult,
-    SpencerResult,
-    BishopBruteForceResult,
-    BishopReliabilityResult,
-    BishopBruteForceReliabilityResult,
-    BishopResult,
-    None,
-]
+DStabilityResult = (
+    UpliftVanResult |
+    UpliftVanParticleSwarmResult |
+    UpliftVanReliabilityResult |
+    UpliftVanParticleSwarmReliabilityResult |
+    SpencerGeneticAlgorithmResult |
+    SpencerReliabilityResult |
+    SpencerGeneticAlgorithmReliabilityResult |
+    SpencerResult |
+    BishopBruteForceResult |
+    BishopReliabilityResult |
+    BishopBruteForceReliabilityResult |
+    BishopResult |
+    None
+)
 
 
 ###########################
@@ -2358,7 +2319,7 @@ DStabilityResult = Union[
 class DStabilityStructure(BaseModelStructure):
     """Highest level DStability class that should be parsed to and serialized from.
 
-    The List[] items (one for each stage in the model) will be stored in a subfolder
+    The list[] items (one for each stage in the model) will be stored in a subfolder
     to multiple json files. Where the first (0) instance
     has no suffix, but the second one has (1 => _1) etc.
 
@@ -2366,15 +2327,15 @@ class DStabilityStructure(BaseModelStructure):
     """
 
     # input part
-    waternets: List[Waternet] = [Waternet(Id="14")]  # waternets/waternet_x.json
-    waternetcreatorsettings: List[WaternetCreatorSettings] = [
+    waternets: list[Waternet] = [Waternet(Id="14")]  # waternets/waternet_x.json
+    waternetcreatorsettings: list[WaternetCreatorSettings] = [
         WaternetCreatorSettings(Id="15")
     ]  # waternetcreatorsettings/waternetcreatorsettings_x.json
-    states: List[State] = [State(Id="16")]  # states/states_x.json
-    statecorrelations: List[StateCorrelation] = [
+    states: list[State] = [State(Id="16")]  # states/states_x.json
+    statecorrelations: list[StateCorrelation] = [
         StateCorrelation(Id="17")
     ]  # statecorrelations/statecorrelations_x.json
-    scenarios: List[Scenario] = [
+    scenarios: list[Scenario] = [
         Scenario(
             Id="0",
             Label="Scenario 1",
@@ -2405,35 +2366,35 @@ class DStabilityStructure(BaseModelStructure):
             ],
         )
     ]
-    soillayers: List[SoilLayerCollection] = [SoilLayerCollection(Id="13")]
+    soillayers: list[SoilLayerCollection] = [SoilLayerCollection(Id="13")]
     soilcorrelation: SoilCorrelation = SoilCorrelation()
     soils: SoilCollection = SoilCollection()
     soilvisualizations: SoilVisualisation = SoilVisualisation()
-    reinforcements: List[Reinforcements] = [Reinforcements(Id="19")]
+    reinforcements: list[Reinforcements] = [Reinforcements(Id="19")]
     projectinfo: ProjectInfo = ProjectInfo()
     nailproperties: NailProperties = NailProperties()
-    loads: List[Loads] = [Loads(Id="18")]
-    decorations: List[Decorations] = [Decorations(Id="12")]
-    calculationsettings: List[CalculationSettings] = [CalculationSettings(Id="20")]
-    geometries: List[Geometry] = [Geometry(Id="11")]
+    loads: list[Loads] = [Loads(Id="18")]
+    decorations: list[Decorations] = [Decorations(Id="12")]
+    calculationsettings: list[CalculationSettings] = [CalculationSettings(Id="20")]
+    geometries: list[Geometry] = [Geometry(Id="11")]
 
     # Output parts
-    uplift_van_results: List[UpliftVanResult] = []
-    uplift_van_particle_swarm_results: List[UpliftVanParticleSwarmResult] = []
-    uplift_van_reliability_results: List[UpliftVanReliabilityResult] = []
-    uplift_van_particle_swarm_reliability_results: List[
+    uplift_van_results: list[UpliftVanResult] = []
+    uplift_van_particle_swarm_results: list[UpliftVanParticleSwarmResult] = []
+    uplift_van_reliability_results: list[UpliftVanReliabilityResult] = []
+    uplift_van_particle_swarm_reliability_results: list[
         UpliftVanParticleSwarmReliabilityResult
     ] = []
-    spencer_results: List[SpencerResult] = []
-    spencer_genetic_algorithm_results: List[SpencerGeneticAlgorithmResult] = []
-    spencer_reliability_results: List[SpencerReliabilityResult] = []
-    spencer_genetic_algorithm_reliability_results: List[
+    spencer_results: list[SpencerResult] = []
+    spencer_genetic_algorithm_results: list[SpencerGeneticAlgorithmResult] = []
+    spencer_reliability_results: list[SpencerReliabilityResult] = []
+    spencer_genetic_algorithm_reliability_results: list[
         SpencerGeneticAlgorithmReliabilityResult
     ] = []
-    bishop_results: List[BishopResult] = []
-    bishop_bruteforce_results: List[BishopBruteForceResult] = []
-    bishop_reliability_results: List[BishopReliabilityResult] = []
-    bishop_bruteforce_reliability_results: List[BishopBruteForceReliabilityResult] = []
+    bishop_results: list[BishopResult] = []
+    bishop_bruteforce_results: list[BishopBruteForceResult] = []
+    bishop_reliability_results: list[BishopReliabilityResult] = []
+    bishop_bruteforce_reliability_results: list[BishopBruteForceReliabilityResult] = []
 
     @model_validator(mode="after")
     def ensure_validity_foreign_keys(self):
@@ -2473,8 +2434,8 @@ class DStabilityStructure(BaseModelStructure):
         return self
 
     def add_default_scenario(
-        self, label: str, notes: str, unique_start_id: Optional[int] = None
-    ) -> Tuple[int, int]:
+        self, label: str, notes: str, unique_start_id: int | None = None
+    ) -> tuple[int, int]:
         """Add a new default (empty) scenario to DStability."""
         if unique_start_id is None:
             unique_start_id = self.get_unique_id()
@@ -2533,8 +2494,8 @@ class DStabilityStructure(BaseModelStructure):
         scenario_index: int,
         label: str,
         notes: str,
-        unique_start_id: Optional[int] = None,
-    ) -> Tuple[int, int]:
+        unique_start_id: int | None = None,
+    ) -> tuple[int, int]:
         """Add a new default (empty) stage to DStability."""
         if unique_start_id is None:
             unique_start_id = self.get_unique_id()
@@ -2582,8 +2543,8 @@ class DStabilityStructure(BaseModelStructure):
         scenario_index: int,
         label: str,
         notes: str,
-        unique_start_id: Optional[int] = None,
-    ) -> Tuple[int, int]:
+        unique_start_id: int | None = None,
+    ) -> tuple[int, int]:
         """Add a new default (empty) calculation to DStability."""
         if unique_start_id is None:
             unique_start_id = self.get_unique_id()
@@ -2762,7 +2723,7 @@ class DStabilityStructure(BaseModelStructure):
 
     def get_result_substructure(
         self, analysis_type: AnalysisTypeEnum, calculation_type: CalculationTypeEnum
-    ) -> List[DStabilityResult]:
+    ) -> list[DStabilityResult]:
         result_types_mapping = {
             AnalysisTypeEnum.UPLIFT_VAN: {
                 "non_probabilistic": self.uplift_van_results,
@@ -2802,7 +2763,7 @@ class ForeignKeys(DStabilityBaseModelStructure):
     as (implicit) foreign keys.
     """
 
-    mapping: Dict[str, Tuple[str, ...]] = {
+    mapping: dict[str, tuple[str, ...]] = {
         "Waternet.Id": ("Stage.WaternetId",),
         "PersistableHeadLine.Id": (
             "PersistableReferenceLine.BottomHeadLineId",
@@ -2845,7 +2806,7 @@ class ForeignKeys(DStabilityBaseModelStructure):
     }
 
     @property
-    def class_fields(self) -> Dict[str, List[str]]:
+    def class_fields(self) -> dict[str, list[str]]:
         """Return a mapping in the form:
         classname: [fields]
         """

--- a/geolib/models/dstability/loads.py
+++ b/geolib/models/dstability/loads.py
@@ -3,7 +3,6 @@ This module handles the four types of loads in DStability.
 """
 
 import abc
-from typing import Optional
 
 from pydantic import Field, model_validator
 from typing_extensions import Annotated
@@ -23,7 +22,7 @@ from .internal import (
 class DStabilityLoad(BaseDataClass):
     """Base Class for Loads."""
 
-    label: Optional[str] = None
+    label: str | None = None
 
     @abc.abstractmethod
     def to_internal_datastructure(self):

--- a/geolib/models/dstability/reinforcements.py
+++ b/geolib/models/dstability/reinforcements.py
@@ -3,7 +3,6 @@ This module handles the three types of reinforcements in DStability.
 """
 
 import abc
-from typing import List, Optional, Tuple
 
 from pydantic import Field
 from typing_extensions import Annotated
@@ -24,7 +23,7 @@ from .internal import (
 class DStabilityReinforcement(BaseDataClass, metaclass=abc.ABCMeta):
     """Base Class for Reinforcements."""
 
-    label: Optional[str] = None
+    label: str | None = None
 
     @abc.abstractmethod
     def _to_internal_datastructure(self):
@@ -51,8 +50,8 @@ class Nail(DStabilityReinforcement):
     use_shear_stress: bool = (
         False  # TODO set on wether or not shearstresses are provided?
     )
-    lateral_stresses: List[Tuple[float, float]] = []
-    shear_stresses: List[Tuple[float, float]] = []
+    lateral_stresses: list[tuple[float, float]] = []
+    shear_stresses: list[tuple[float, float]] = []
 
     def _to_internal_datastructure(self) -> PersistableNail:
         model_dump = self.model_dump()

--- a/geolib/models/dstability/serializer.py
+++ b/geolib/models/dstability/serializer.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from io import BytesIO
-from typing import Dict, Union, _GenericAlias
+from typing import _GenericAlias
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from pydantic import DirectoryPath, FilePath
@@ -17,8 +17,8 @@ class DStabilityBaseSerializer(BaseSerializer, metaclass=ABCMeta):
 
     ds: DStabilityStructure
 
-    def serialize(self) -> Dict:
-        serialized_datastructure: Dict = {}
+    def serialize(self) -> dict:
+        serialized_datastructure: dict = {}
 
         for field, fieldtype in get_filtered_type_hints(self.ds):
             # On List types, write a folder
@@ -70,7 +70,7 @@ class DStabilityInputSerializer(DStabilityBaseSerializer):
 class DStabilityInputZipSerializer(DStabilityBaseSerializer):
     """DStabilSerializer for zipped.stix files."""
 
-    def write(self, filepath: Union[FilePath, BytesIO]) -> Union[FilePath, BytesIO]:
+    def write(self, filepath: FilePath | BytesIO) -> FilePath | BytesIO:
         with ZipFile(filepath, mode="w", compression=ZIP_DEFLATED) as zip:
             serialized_datastructure = self.serialize()
 

--- a/geolib/models/meta.py
+++ b/geolib/models/meta.py
@@ -13,7 +13,6 @@ such as an compute endpoint.
 
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 from pydantic import AnyHttpUrl, DirectoryPath
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -47,11 +46,11 @@ class MetaData(BaseSettings):
 
     # For calculations
     console_folder: DirectoryPath = Path(".")
-    dstability_console_path: Optional[Path] = None
-    dgeoflow_console_path: Optional[Path] = None
-    dsheetpiling_console_path: Optional[Path] = None
-    dsettlement_console_path: Optional[Path] = None
-    dfoundations_console_path: Optional[Path] = None
+    dstability_console_path: Path | None = None
+    dgeoflow_console_path: Path | None = None
+    dsheetpiling_console_path: Path | None = None
+    dsettlement_console_path: Path | None = None
+    dfoundations_console_path: Path | None = None
 
     timeout: int = 10 * 60  # in seconds, so 10 minutes
 

--- a/geolib/models/parsers.py
+++ b/geolib/models/parsers.py
@@ -1,5 +1,4 @@
 import abc
-from typing import List
 
 from pydantic import FilePath
 
@@ -10,7 +9,7 @@ from geolib.models.base_model_structure import BaseModelStructure
 class BaseParser(abc.ABC):
     @property
     @abc.abstractmethod
-    def suffix_list(self) -> List[str]:
+    def suffix_list(self) -> list[str]:
         raise NotConcreteError
 
     @abc.abstractmethod

--- a/geolib/models/serializers.py
+++ b/geolib/models/serializers.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, BinaryIO, Dict, Union
+from typing import Any, BinaryIO
 
 from pydantic import FilePath
 
@@ -9,12 +9,12 @@ from geolib.models import BaseDataClass
 class BaseSerializer(BaseDataClass):
     """Basic class for serializers."""
 
-    ds: Dict[str, Any]
+    ds: dict[str, Any]
 
     def render(self) -> str:
         return str(self.ds)
 
-    def write(self, filename: Union[FilePath, BinaryIO]):
+    def write(self, filename: FilePath | BinaryIO):
         """Write serialized model to Filepath or BytesIO buffer"""
         # if filename is pathlike, open file (in text mode) and write str
         if isinstance(filename, Path):

--- a/geolib/models/utils.py
+++ b/geolib/models/utils.py
@@ -1,5 +1,5 @@
 # FROM https://github.com/python/cpython/blob/6292be7adf247589bbf03524f8883cb4cb61f3e9/Lib/typing.py
-from typing import List, Tuple, Type, _GenericAlias
+from typing import _GenericAlias
 from typing import get_args as get_args
 from typing import get_type_hints
 
@@ -19,14 +19,14 @@ def is_list(tp):
     return isinstance(tp, _GenericAlias) and tp._name == "List"
 
 
-def get_filtered_type_hints(class_type: Type) -> List[Tuple[str, Type]]:
+def get_filtered_type_hints(class_type: type) -> list[tuple[str, type]]:
     """Gets all the (valid) type hints for a given class.
 
     Args:
-        class_type (Type): Class to extract property fields.
+        class_type (type): Class to extract property fields.
 
     Returns:
-        List[Tuple[str, Type]]: Filtered list of tuples representing field name and type.
+        list[tuple[str, type]]: Filtered list of tuples representing field name and type.
     """
     return [
         (field_name, field)
@@ -35,14 +35,14 @@ def get_filtered_type_hints(class_type: Type) -> List[Tuple[str, Type]]:
     ]
 
 
-def get_required_class_field(class_type: Type) -> List[Tuple[str, Type]]:
+def get_required_class_field(class_type: type) -> list[tuple[str, type]]:
     """Gets all the (valid) class fields which are mandatory.
 
     Args:
-        class_type (Type): [description]
+        class_type (type): [description]
 
     Returns:
-        List[Tuple[str, Type]]: [description]
+        list[tuple[str, type]]: [description]
     """
     return [
         (field_name, field)

--- a/geolib/service/main.py
+++ b/geolib/service/main.py
@@ -2,7 +2,6 @@ import secrets
 import shutil
 import uuid
 from pathlib import Path, PosixPath, WindowsPath
-from typing import List
 
 from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
@@ -35,10 +34,10 @@ security = HTTPBasic()
 
 # Models (types) are defined below, because they are used in the
 # signatures of the functions and they differ between Pydantic v1 and v2.
-dsettlement_list = Annotated[List[DSettlementModel], Field(min_length=1)]
-dfoundation_list = Annotated[List[DFoundationsModel], Field(min_length=1)]
-dsheetpile_list = Annotated[List[DSheetPilingModel], Field(min_length=1)]
-dstability_list = Annotated[List[DStabilityModel], Field(min_length=1)]
+dsettlement_list = Annotated[list[DSettlementModel], Field(min_length=1)]
+dfoundation_list = Annotated[list[DFoundationsModel], Field(min_length=1)]
+dsheetpile_list = Annotated[list[DSheetPilingModel], Field(min_length=1)]
+dstability_list = Annotated[list[DStabilityModel], Field(min_length=1)]
 
 
 def get_current_username(credentials: HTTPBasicCredentials = Depends(security)):
@@ -129,7 +128,7 @@ async def calculate_many_dsettlementmodels(
     models: dsettlement_list,
     background_tasks: BackgroundTasks,
     _: str = Depends(get_current_username),
-) -> List[DSettlementModel]:
+) -> list[DSettlementModel]:
     return execute_many(models, background_tasks)
 
 
@@ -138,7 +137,7 @@ async def calculate_many_dfoundationsmodel(
     models: dfoundation_list,
     background_tasks: BackgroundTasks,
     _: str = Depends(get_current_username),
-) -> List[DFoundationsModel]:
+) -> list[DFoundationsModel]:
     return execute_many(models, background_tasks)
 
 
@@ -147,7 +146,7 @@ async def calculate_many_dsheetpilingmodel(
     models: dsheetpile_list,
     background_tasks: BackgroundTasks,
     _: str = Depends(get_current_username),
-) -> List[DSheetPilingModel]:
+) -> list[DSheetPilingModel]:
     return execute_many(models, background_tasks)
 
 
@@ -156,7 +155,7 @@ async def calculate_many_dstabilitymodel(
     models: dstability_list,
     background_tasks: BackgroundTasks,
     _: str = Depends(get_current_username),
-) -> List[DStabilityModel]:
+) -> list[DStabilityModel]:
     return execute_many(models, background_tasks)
 
 

--- a/geolib/soils/layers.py
+++ b/geolib/soils/layers.py
@@ -3,9 +3,6 @@ Profile and Layer classes which are used by both D-Foundations and DSheetPiling.
 D-Foundations often requires more parameters, which are unused for DSheetPiling.
 
 """
-
-from typing import List
-
 from geolib.geometry.one import Point
 from geolib.models import BaseDataClass
 from geolib.soils import Soil
@@ -20,8 +17,8 @@ class CPT(BaseDataClass):
         Add Friction and other parameters?
     """
 
-    z: List[float]
-    qc: List[float]
+    z: list[float]
+    qc: list[float]
 
 
 class CPTRule(BaseDataClass):
@@ -54,7 +51,7 @@ class Profile(BaseDataClass):
     """
 
     label: str
-    layers: List[ProfileLayer]
+    layers: list[ProfileLayer]
     phreatic_level: float
     pile_tip_level: float
     overconsolidation_ratio: float

--- a/geolib/soils/soil.py
+++ b/geolib/soils/soil.py
@@ -1,6 +1,5 @@
 from enum import Enum, IntEnum
 from math import isfinite
-from typing import List, Optional, Union
 
 from pydantic import field_validator
 
@@ -33,14 +32,14 @@ class StochasticParameter(SoilBaseModel):
     """
 
     is_probabilistic: bool = False
-    mean: Optional[float] = None
-    standard_deviation: Optional[float] = 0
-    distribution_type: Optional[DistributionType] = DistributionType.Normal
-    correlation_coefficient: Optional[float] = None
-    low_characteristic_value: Optional[float] = None
-    high_characteristic_value: Optional[float] = None
-    low_design_value: Optional[float] = None
-    high_design_value: Optional[float] = None
+    mean: float | None = None
+    standard_deviation: float | None = 0
+    distribution_type: DistributionType | None = DistributionType.Normal
+    correlation_coefficient: float | None = None
+    low_characteristic_value: float | None = None
+    high_characteristic_value: float | None = None
+    low_design_value: float | None = None
+    high_design_value: float | None = None
 
 
 class ShearStrengthModelTypePhreaticLevel(Enum):
@@ -76,14 +75,12 @@ class MohrCoulombParameters(SoilBaseModel):
     Mohr Coulomb parameters class
     """
 
-    cohesion: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    dilatancy_angle: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    friction_angle: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    friction_angle_interface: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    is_delta_angle_automatically_calculated: Optional[bool] = None
-    cohesion_and_friction_angle_correlated: Optional[bool] = None
+    cohesion: float | StochasticParameter | None = StochasticParameter()
+    dilatancy_angle: float | StochasticParameter | None = StochasticParameter()
+    friction_angle: float | StochasticParameter | None = StochasticParameter()
+    friction_angle_interface: float | StochasticParameter | None = StochasticParameter()
+    is_delta_angle_automatically_calculated: bool | None = None
+    cohesion_and_friction_angle_correlated: bool | None = None
 
 
 class SuTablePoint(SoilBaseModel):
@@ -97,9 +94,9 @@ class SigmaTauTablePoint(SoilBaseModel):
 
 
 class SigmaTauParameters(SoilBaseModel):
-    sigma_tau_table: Optional[List[SigmaTauTablePoint]] = None
-    probabilistic_sigma_tau_table: Optional[bool] = None
-    sigma_tau_table_variation_coefficient: Optional[float] = None
+    sigma_tau_table: list[SigmaTauTablePoint] = None | None
+    probabilistic_sigma_tau_table: bool | None = None
+    sigma_tau_table_variation_coefficient: float | None = None
 
     def to_sigma_tau_table_points(self):
         from geolib.models.dstability.internal import PersistableSigmaTauTablePoint
@@ -122,21 +119,17 @@ class UndrainedParameters(SoilBaseModel):
     Undrained shear strength parameters class. This class includes the SU Table and SHANSEP model variables included in D-Stability.
     """
 
-    shear_strength_ratio: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    shear_strength_ratio_and_shear_strength_exponent_correlated: Optional[bool] = None
-    strength_increase_exponent: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    s_and_m_correlated: Optional[bool] = None
-    undrained_shear_strength: Optional[float] = None
-    undrained_shear_strength_top: Optional[float] = None
-    undrained_shear_strength_bottom: Optional[float] = None
-    undrained_shear_strength_bearing_capacity_factor: Optional[float] = None
-    su_table: Optional[List[SuTablePoint]] = None
-    probabilistic_su_table: Optional[bool] = None
-    su_table_variation_coefficient: Optional[float] = None
+    shear_strength_ratio: float | StochasticParameter | None = StochasticParameter()
+    shear_strength_ratio_and_shear_strength_exponent_correlated: bool | None = None
+    strength_increase_exponent: float | StochasticParameter | None = StochasticParameter()
+    s_and_m_correlated: bool | None = None
+    undrained_shear_strength: float | None = None
+    undrained_shear_strength_top: float | None = None
+    undrained_shear_strength_bottom: float | None = None
+    undrained_shear_strength_bearing_capacity_factor: float | None = None
+    su_table: list[SuTablePoint] = None | None
+    probabilistic_su_table: bool | None = None
+    su_table_variation_coefficient: float | None = None
 
     def to_su_table_points(self):
         from geolib.models.dstability.internal import PersistableSuTablePoint
@@ -170,31 +163,17 @@ class BjerrumParameters(SoilBaseModel):
             coef_secondary_compression_Ca
     """
 
-    input_type_is_comp_ratio: Optional[bool] = None
-    reloading_ratio: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    primary_compression_ratio: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    correlation_reload_primary_compression_ratio: Optional[float] = None
-    reloading_index: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    primary_compression_index: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    coef_secondary_compression_Ca: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    reloading_swelling_RR: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    compression_ratio_CR: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    reloading_swelling_index_Cr: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    compression_index_Cc: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
+    input_type_is_comp_ratio: bool | None = None
+    reloading_ratio: float | StochasticParameter | None = StochasticParameter()
+    primary_compression_ratio: float | StochasticParameter | None = StochasticParameter()
+    correlation_reload_primary_compression_ratio: float | None = None
+    reloading_index: float | StochasticParameter | None = StochasticParameter()
+    primary_compression_index: float | StochasticParameter | None = StochasticParameter()
+    coef_secondary_compression_Ca: float | StochasticParameter | None = StochasticParameter()
+    reloading_swelling_RR: float | StochasticParameter | None = StochasticParameter()
+    compression_ratio_CR: float | StochasticParameter | None = StochasticParameter()
+    reloading_swelling_index_Cr: float | StochasticParameter | None = StochasticParameter()
+    compression_index_Cc: float | StochasticParameter | None = StochasticParameter()
 
 
 class StateType(Enum):
@@ -204,30 +183,22 @@ class StateType(Enum):
 
 
 class IsotacheParameters(SoilBaseModel):
-    precon_isotache_type: Optional[StateType] = None
-    reloading_swelling_constant_a: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )  # SoilStdPriCompIndex
-    primary_compression_constant_b: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )  # SoilStdSecCompIndex
-    secondary_compression_constant_c: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )  # SoilStdSecCompRate
+    precon_isotache_type: StateType | None = None
+    reloading_swelling_constant_a: float | StochasticParameter | None = StochasticParameter()  # SoilStdPriCompIndex
+    primary_compression_constant_b: float | StochasticParameter | None = StochasticParameter()  # SoilStdSecCompIndex
+    secondary_compression_constant_c: float | StochasticParameter | None = StochasticParameter()  # SoilStdSecCompRate
 
 
 class KoppejanParameters(SoilBaseModel):
-    precon_koppejan_type: Optional[StateType] = None
-    preconsolidation_pressure: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    soil_ap_as_approximation_by_Cp_Cs: Optional[bool] = False
-    primary_Cp: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    primary_Cp_point: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    secular_Cs: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    secular_Cs_point: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    primary_Ap: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    primary_Asec: Optional[Union[float, StochasticParameter]] = StochasticParameter()
+    precon_koppejan_type: StateType | None = None
+    preconsolidation_pressure: float | StochasticParameter | None = StochasticParameter()
+    soil_ap_as_approximation_by_Cp_Cs: bool | None = False
+    primary_Cp: float | StochasticParameter | None = StochasticParameter()
+    primary_Cp_point: float | StochasticParameter | None = StochasticParameter()
+    secular_Cs: float | StochasticParameter | None = StochasticParameter()
+    secular_Cs_point: float | StochasticParameter | None = StochasticParameter()
+    primary_Ap: float | StochasticParameter | None = StochasticParameter()
+    primary_Asec: float | StochasticParameter | None = StochasticParameter()
 
 
 class StorageTypes(IntEnum):
@@ -242,29 +213,17 @@ class StorageParameters(SoilBaseModel):
     of the D-Settlement this value is displayed as [m/s].
     """
 
-    vertical_permeability: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    permeability_horizontal_factor: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    horizontal_permeability: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    storage_type: Optional[StorageTypes] = None
-    permeability_strain_type: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter(mean=1e15)
-    )
-    vertical_consolidation_coefficient: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
+    vertical_permeability: float | StochasticParameter | None = StochasticParameter()
+    permeability_horizontal_factor: float | StochasticParameter | None = StochasticParameter()
+    horizontal_permeability: float | StochasticParameter | None = StochasticParameter()
+    storage_type: StorageTypes | None = None
+    permeability_strain_type: float | StochasticParameter | None = StochasticParameter(mean=1e15)
+    vertical_consolidation_coefficient: float | StochasticParameter | None = StochasticParameter()
 
 
 class SoilWeightParameters(SoilBaseModel):
-    saturated_weight: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    unsaturated_weight: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
+    saturated_weight: float | StochasticParameter | None = StochasticParameter()
+    unsaturated_weight: float | StochasticParameter | None = StochasticParameter()
 
 
 class GrainType(IntEnum):
@@ -277,21 +236,19 @@ class SoilClassificationParameters(SoilBaseModel):
     Soil classification class
     """
 
-    initial_void_ratio: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    min_void_ratio: Optional[float] = None
-    max_void_ratio: Optional[float] = None
-    porosity: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    relative_density: Optional[float] = None
-    d_50: Optional[float] = None
-    grain_type: Optional[GrainType] = (
+    initial_void_ratio: float | StochasticParameter | None = StochasticParameter()
+    min_void_ratio: float | None = None
+    max_void_ratio: float | None = None
+    porosity: float | StochasticParameter | None = StochasticParameter()
+    relative_density: float | None = None
+    d_50: float | None = None
+    grain_type: GrainType | None = (
         GrainType.FINE
     )  # TODO this must refer to a intenum class
 
 
 class SoilStiffnessParameters(SoilBaseModel):
-    emod_menard: Optional[float] = None
+    emod_menard: float | None = None
 
 
 class ModulusSubgradeReaction(IntEnum):
@@ -306,27 +263,27 @@ class LambdaType(IntEnum):
 
 
 class SubgradeReactionParameters(SoilBaseModel):
-    modulus_subgrade_reaction_type: Optional[ModulusSubgradeReaction] = None
-    lambda_type: Optional[LambdaType] = None
-    tangent_secant_1: Optional[float] = None
-    tangent_secant_2: Optional[float] = None
-    tangent_secant_3: Optional[float] = None
-    k_o_top: Optional[float] = None
-    k_1_top: Optional[float] = None
-    k_2_top: Optional[float] = None
-    k_3_top: Optional[float] = None
-    k_4_top: Optional[float] = None
-    k_o_bottom: Optional[float] = None
-    k_1_bottom: Optional[float] = None
-    k_2_bottom: Optional[float] = None
-    k_3_bottom: Optional[float] = None
-    k_4_bottom: Optional[float] = None
-    k_1_top_side: Optional[float] = None
-    k_2_top_side: Optional[float] = None
-    k_3_top_side: Optional[float] = None
-    k_1_bottom_side: Optional[float] = None
-    k_2_bottom_side: Optional[float] = None
-    k_3_bottom_side: Optional[float] = None
+    modulus_subgrade_reaction_type: ModulusSubgradeReaction | None = None
+    lambda_type: LambdaType | None = None
+    tangent_secant_1: float | None = None
+    tangent_secant_2: float | None = None
+    tangent_secant_3: float | None = None
+    k_o_top: float | None = None
+    k_1_top: float | None = None
+    k_2_top: float | None = None
+    k_3_top: float | None = None
+    k_4_top: float | None = None
+    k_o_bottom: float | None = None
+    k_1_bottom: float | None = None
+    k_2_bottom: float | None = None
+    k_3_bottom: float | None = None
+    k_4_bottom: float | None = None
+    k_1_top_side: float | None = None
+    k_2_top_side: float | None = None
+    k_3_top_side: float | None = None
+    k_1_bottom_side: float | None = None
+    k_2_bottom_side: float | None = None
+    k_3_bottom_side: float | None = None
 
 
 class EarthPressureCoefficientsType(IntEnum):
@@ -335,12 +292,12 @@ class EarthPressureCoefficientsType(IntEnum):
 
 
 class EarthPressureCoefficients(SoilBaseModel):
-    earth_pressure_coefficients_type: Optional[EarthPressureCoefficientsType] = (
+    earth_pressure_coefficients_type: EarthPressureCoefficientsType | None = (
         EarthPressureCoefficientsType.BRINCHHANSEN
     )
-    active: Optional[float] = None
-    neutral: Optional[float] = None
-    passive: Optional[float] = None
+    active: float | None = None
+    neutral: float | None = None
+    passive: float | None = None
 
 
 class HorizontalBehaviourType(IntEnum):
@@ -354,9 +311,9 @@ class HorizontalBehaviour(SoilBaseModel):
     Horizontal behaviour class
     """
 
-    horizontal_behavior_type: Optional[HorizontalBehaviourType] = None
-    soil_elasticity: Optional[float] = None
-    soil_default_elasticity: Optional[bool] = None
+    horizontal_behavior_type: HorizontalBehaviourType | None = None
+    soil_elasticity: float | None = None
+    soil_default_elasticity: bool | None = None
 
 
 class ConeResistance(SoilBaseModel):
@@ -364,15 +321,15 @@ class ConeResistance(SoilBaseModel):
     Cone resistance class
     """
 
-    max_cone_resistance_type: Optional[Enum] = None
-    max_cone_resistance: Optional[float] = None
+    max_cone_resistance_type: Enum | None = None
+    max_cone_resistance: float | None = None
 
 
 class StatePoint(SoilBaseModel):
-    state_point_id: Optional[str] = None
-    state_layer_id: Optional[str] = None
-    state_point_type: Optional[StateType] = None
-    state_point_is_probabilistic: Optional[bool] = None
+    state_point_id: str | None = None
+    state_layer_id: str | None = None
+    state_point_type: StateType | None = None
+    state_point_is_probabilistic: bool | None = None
 
 
 class StateLine(SoilBaseModel):
@@ -381,23 +338,21 @@ class StateLine(SoilBaseModel):
     TODO decide if we want cross-dependency to geometry class
     """
 
-    state_line_points: Optional[List[Point]]
+    state_line_points: list[Point] | None
 
 
 class SoilState(SoilBaseModel):
-    use_equivalent_age: Optional[bool] = None
-    equivalent_age: Optional[float] = None
-    state_points: Optional[StatePoint] = None
-    state_lines: Optional[StateLine] = None
+    use_equivalent_age: bool | None = None
+    equivalent_age: float | None = None
+    state_points: StatePoint | None = None
+    state_lines: StateLine | None = None
 
-    yield_stress_layer: Optional[Union[float, StochasticParameter]] = (
-        StochasticParameter()
-    )
-    ocr_layer: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    pop_layer: Optional[Union[float, StochasticParameter]] = StochasticParameter()
-    secondary_swelling_reduced: Optional[bool] = None
-    secondary_swelling_factor: Optional[float] = None
-    unloading_stress_ratio: Optional[float] = None
+    yield_stress_layer: float | StochasticParameter | None = StochasticParameter()
+    ocr_layer: float | StochasticParameter | None = StochasticParameter()
+    pop_layer: float | StochasticParameter | None = StochasticParameter()
+    secondary_swelling_reduced: bool | None = None
+    secondary_swelling_factor: float | None = None
+    unloading_stress_ratio: float | None = None
 
 
 class SoilType(IntEnum):
@@ -414,49 +369,45 @@ class SoilType(IntEnum):
 class Soil(SoilBaseModel):
     """Soil Material."""
 
-    id: Optional[str] = None
-    name: Optional[str] = None
-    code: Optional[str] = None
+    id: str | None = None
+    name: str | None = None
+    code: str | None = None
     color: Color = Color("grey")
 
-    mohr_coulomb_parameters: Optional[MohrCoulombParameters] = MohrCoulombParameters()
-    sigma_tau_parameters: Optional[SigmaTauParameters] = SigmaTauParameters()
-    undrained_parameters: Optional[UndrainedParameters] = UndrainedParameters()
-    bjerrum_parameters: Optional[BjerrumParameters] = BjerrumParameters()
-    isotache_parameters: Optional[IsotacheParameters] = IsotacheParameters()
-    koppejan_parameters: Optional[KoppejanParameters] = KoppejanParameters()
-    storage_parameters: Optional[StorageParameters] = StorageParameters()
-    soil_weight_parameters: Optional[SoilWeightParameters] = SoilWeightParameters()
-    soil_classification_parameters: Optional[SoilClassificationParameters] = (
+    mohr_coulomb_parameters: MohrCoulombParameters | None = MohrCoulombParameters()
+    sigma_tau_parameters: SigmaTauParameters | None = SigmaTauParameters()
+    undrained_parameters: UndrainedParameters | None = UndrainedParameters()
+    bjerrum_parameters: BjerrumParameters | None = BjerrumParameters()
+    isotache_parameters: IsotacheParameters | None = IsotacheParameters()
+    koppejan_parameters: KoppejanParameters | None = KoppejanParameters()
+    storage_parameters: StorageParameters | None = StorageParameters()
+    soil_weight_parameters: SoilWeightParameters | None = SoilWeightParameters()
+    soil_classification_parameters: SoilClassificationParameters | None = (
         SoilClassificationParameters()
     )
-    soil_stiffness_parameters: Optional[SoilStiffnessParameters] = (
+    soil_stiffness_parameters: SoilStiffnessParameters | None = (
         SoilStiffnessParameters()
     )
 
-    horizontal_behaviour: Optional[HorizontalBehaviour] = HorizontalBehaviour()
-    cone_resistance: Optional[ConeResistance] = ConeResistance()
-    use_tension: Optional[bool] = None
-    use_probabilistic_defaults: Optional[bool] = False
-    soil_type_settlement_by_vibrations: Optional[SoilType] = SoilType.SAND
-    soil_type_nl: Optional[SoilType] = SoilType.SAND
-    soil_state: Optional[SoilState] = SoilState()
-    shear_strength_model_above_phreatic_level: Optional[
-        ShearStrengthModelTypePhreaticLevel
-    ] = None
-    shear_strength_model_below_phreatic_level: Optional[
-        ShearStrengthModelTypePhreaticLevel
-    ] = None
-    is_drained: Optional[bool] = None
-    is_probabilistic: Optional[bool] = None
+    horizontal_behaviour: HorizontalBehaviour | None = HorizontalBehaviour()
+    cone_resistance: ConeResistance | None = ConeResistance()
+    use_tension: bool | None = None
+    use_probabilistic_defaults: bool | None = False
+    soil_type_settlement_by_vibrations: SoilType | None = SoilType.SAND
+    soil_type_nl: SoilType | None = SoilType.SAND
+    soil_state: SoilState | None = SoilState()
+    shear_strength_model_above_phreatic_level: ShearStrengthModelTypePhreaticLevel | None = None
+    shear_strength_model_below_phreatic_level: ShearStrengthModelTypePhreaticLevel | None = None
+    is_drained: bool | None = None
+    is_probabilistic: bool | None = None
 
-    earth_pressure_coefficients: Optional[EarthPressureCoefficients] = (
+    earth_pressure_coefficients: EarthPressureCoefficients | None = (
         EarthPressureCoefficients()
     )
-    subgrade_reaction_parameters: Optional[SubgradeReactionParameters] = (
+    subgrade_reaction_parameters: SubgradeReactionParameters | None = (
         SubgradeReactionParameters()
     )
-    shell_factor: Optional[float] = None
+    shell_factor: float | None = None
 
     @field_validator("id", mode="before")
     @classmethod

--- a/tests/models/dfoundations/test_dfoundations_internal.py
+++ b/tests/models/dfoundations/test_dfoundations_internal.py
@@ -1,5 +1,4 @@
 from random import randint
-from typing import Callable, Type
 
 import pytest
 
@@ -645,8 +644,8 @@ class TestInternalOutputDFoundations:
         self,
         text_to_parse: str,
         property_name: str,
-        parsing_type: Type,
-        expected_type: Type,
+        parsing_type: type,
+        expected_type: type,
     ):
         # 1. Run test
         group_text = self.get_group_text(text_to_parse)

--- a/tests/models/dfoundations/test_dfoundations_model.py
+++ b/tests/models/dfoundations/test_dfoundations_model.py
@@ -2,7 +2,6 @@ import logging
 import os
 from io import BytesIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 from teamcity import is_running_under_teamcity
@@ -132,7 +131,7 @@ class TestDFoundationsModel:
         ],
     )
     def test_given_filepath_when_parse_then_does_not_raise(
-        self, filename: Path, structure: Type
+        self, filename: Path, structure: type
     ):
         # 1. Set up test data
         test_folder = Path(TestUtils.get_local_test_data_dir(test_file_directory))

--- a/tests/models/dfoundations/test_dfoundations_structures.py
+++ b/tests/models/dfoundations/test_dfoundations_structures.py
@@ -1,7 +1,6 @@
 from contextlib import nullcontext as does_not_raise
 from random import choice, randint
 from string import ascii_lowercase
-from typing import Dict, List, Type, Union
 
 import pytest
 from pydantic_core._pydantic_core import ValidationError
@@ -35,7 +34,7 @@ class TestDFoundationsCPTCollectionWrapper:
             first_value: int
 
         class test_wrapped_collection(DFoundationsCPTCollectionWrapper):
-            collection: List[test_simple_element]
+            collection: list[test_simple_element]
 
         # 1. Define test data.
         structure_first_value_list = [42, 24]
@@ -66,22 +65,22 @@ class TestDFoundationsCPTCollectionWrapper:
 
 class TestDFoundationsTableWrapper:
     class test_simple_table(DFoundationsTableWrapper):
-        value: List[Dict[str, Union[int, float, str]]]
+        value: list[dict[str, int | float | str]]
 
     class test_table_str_first(DFoundationsTableWrapper):
-        value: List[Dict[str, Union[str, int, float]]]
+        value: list[dict[str, str | int | float]]
 
     class test_table_float_first(DFoundationsTableWrapper):
-        value: List[Dict[str, Union[float, int, str]]]
+        value: list[dict[str, float | int | str]]
 
     class test_table_only_int(DFoundationsTableWrapper):
-        value: List[Dict[str, int]]
+        value: list[dict[str, int]]
 
     class test_table_only_float(DFoundationsTableWrapper):
-        value: List[Dict[str, float]]
+        value: list[dict[str, float]]
 
     class test_table_only_str(DFoundationsTableWrapper):
-        value: List[Dict[str, str]]
+        value: list[dict[str, str]]
 
     @pytest.mark.integrationtest
     @pytest.mark.parametrize(
@@ -114,7 +113,7 @@ class TestDFoundationsTableWrapper:
         ],
     )
     def test_given_dfoundationstablewrapper_when_parse_type_done_in_order(
-        self, table_type: Type, expected_column_type: List[Type], run_expectation
+        self, table_type: type, expected_column_type: list[type], run_expectation
     ):
         # 1. Define test data
         input_dict = {"int": 42, "float": 4.2, "str": "'42'"}

--- a/tests/models/dsettlement/test_acceptance.py
+++ b/tests/models/dsettlement/test_acceptance.py
@@ -4,7 +4,6 @@ import pathlib
 import shutil
 from datetime import timedelta
 from pathlib import Path
-from typing import List
 from warnings import warn
 
 import pydantic

--- a/tests/models/dsettlement/test_dsettlement_model.py
+++ b/tests/models/dsettlement/test_dsettlement_model.py
@@ -2,7 +2,6 @@ import os
 from datetime import timedelta
 from io import BytesIO
 from pathlib import Path
-from typing import List
 
 import pytest
 from pydantic import ValidationError
@@ -447,7 +446,7 @@ class TestDSettlementModel:
         ],
     )
     def test_add_simpleboundary(
-        self, dserie_points: List[Point], expected_result: List[int]
+        self, dserie_points: list[Point], expected_result: list[int]
     ):
         # 1. Set up test model
         model = DSettlementModel()

--- a/tests/models/dsettlement/test_dsettlement_structures.py
+++ b/tests/models/dsettlement/test_dsettlement_structures.py
@@ -1,5 +1,3 @@
-from typing import Any, Dict, List
-
 import pytest
 
 from geolib.models.dseries_parser import DSeriesRepeatedGroupedProperties
@@ -26,7 +24,7 @@ class TestDSerieRepeatedTableStructure:
     @pytest.mark.integrationtest
     def test_given_text_when_parse_text_then_return_structure(self):
         class repeated_table(DSerieRepeatedTableStructure):
-            repeated_table: Dict[int, List[Dict[str, int]]]
+            repeated_table: dict[int, list[dict[str, int]]]
 
         # 1. Define test data
         text_to_parse = """[COLUMN INDICATION]

--- a/tests/models/dsheetpiling/test_dsheetpiling_model.py
+++ b/tests/models/dsheetpiling/test_dsheetpiling_model.py
@@ -2,7 +2,6 @@ import logging
 import os
 from io import BytesIO
 from pathlib import Path
-from typing import Type
 
 import pytest
 
@@ -99,7 +98,7 @@ class TestDsheetPilingModel:
         ],
     )
     def test_given_filepath_when_parse_then_does_not_raise(
-        self, filename: Path, structure: Type
+        self, filename: Path, structure: type
     ):
         # 1. Set up test data
         test_folder = Path(TestUtils.get_local_test_data_dir(test_file_directory))

--- a/tests/models/dsheetpiling/test_dsheetpiling_structures.py
+++ b/tests/models/dsheetpiling/test_dsheetpiling_structures.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
@@ -16,7 +16,7 @@ class TestDSheetpilingSurchargeLoad:
     @pytest.mark.unittest
     def test_when_get_list_field_names_returns_all_fields_and_point(self):
         class dummy_with_lists(DSheetpilingSurchargeLoad):
-            property_one: List[str]
+            property_one: list[str]
             property_two: str
 
         expected_output = ["property_one", "point"]
@@ -66,7 +66,7 @@ class TestDSheetpilingWithNumberOfRowsTable:
     def test_given_table_with_number_of_rows_on_top_structure_is_parsed(self):
         # 1. Define test data
         class test_structure(DSheetpilingWithNumberOfRowsTable):
-            test_structure: List[Dict[str, float]]
+            test_structure: list[dict[str, float]]
 
         text_to_parse = """[TABLE]
             DataCount=2
@@ -135,7 +135,7 @@ class TestDSheetpilingUnwrappedTable:
             value: float
 
         class DummyUnwrappedTable(DSheetpilingUnwrappedTable):
-            dummyunwrappedtable: List[DummyTableEntry]
+            dummyunwrappedtable: list[DummyTableEntry]
 
         # 1. Define test data
         text_to_parse = """ 2 values
@@ -159,7 +159,7 @@ class TestDSheetpilingUnwrappedTable:
             value: float
 
         class DummyUnwrappedTable(DSheetpilingUnwrappedTable):
-            dummyunwrappedtable: List[DummyTableEntry]
+            dummyunwrappedtable: list[DummyTableEntry]
 
         # 1. Define test data
         text_to_parse = """ 1 value

--- a/tests/models/dsheetpiling/test_internal_dsheetpiling.py
+++ b/tests/models/dsheetpiling/test_internal_dsheetpiling.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Callable, List
+from typing import Callable
 
 import pytest
 
@@ -617,7 +617,7 @@ class TestInternalParseInputStructure:
         assert mfd_table["shear_force"] == 0
         assert mfd_table["displacements"] == -193.89808
 
-    def validate_side_list_structure(self, side_list: List[SideOutput]):
+    def validate_side_list_structure(self, side_list: list[SideOutput]):
         assert side_list
         assert len(side_list) == 2
         for side in side_list:
@@ -1129,7 +1129,7 @@ class TestInternalParseOutputStructure:
         assert mfd_table["shear_force"] == 0
         assert mfd_table["displacements"] == -193.89808
 
-    def validate_side_list_structure(self, side_list: List[SideOutput]):
+    def validate_side_list_structure(self, side_list: list[SideOutput]):
         assert side_list
         assert len(side_list) == 2
         for side in side_list:
@@ -1147,13 +1147,13 @@ class TestInternalParseOutputStructure:
         )
         self.validate_side_list_structure(output_construction_stage.side)
 
-    def validate_points_on_sheetpile_list(self, pos_list: List[PointsOnSheetpile]):
+    def validate_points_on_sheetpile_list(self, pos_list: list[PointsOnSheetpile]):
         assert len(pos_list) == 2
         for pos in pos_list:
             self.validate_points_on_sheetpile(pos)
 
     def validate_output_construction_stage_list(
-        self, ocs_list: List[OutputConstructionStage]
+        self, ocs_list: list[OutputConstructionStage]
     ):
         assert len(ocs_list) == 2
         for ocs in ocs_list:

--- a/tests/models/dsheetpiling/test_profiles.py
+++ b/tests/models/dsheetpiling/test_profiles.py
@@ -1,5 +1,5 @@
 from contextlib import nullcontext as does_not_raise
-from typing import Callable, List
+from typing import Callable
 
 import pytest
 from pydantic import ValidationError
@@ -23,7 +23,7 @@ _SOIL_TEST_NAME_1: str = "Clay"
 _SOIL_TEST_NAME_2: str = "Sand"
 _PROFILE_TEST_NAME: str = "test profiel"
 _PROFILE_TEST_COORDINATES: Point = Point(x=100, y=250)
-_TEST_LAYERS: List[SoilLayer] = [
+_TEST_LAYERS: list[SoilLayer] = [
     SoilLayer(top_of_layer=0, soil=_SOIL_TEST_NAME_1),
     SoilLayer(top_of_layer=-2, soil=_SOIL_TEST_NAME_2),
 ]
@@ -193,7 +193,7 @@ class TestSoilProfile:
         ],
     )
     def test_profile_initialization_with_different_points_arguments(
-        self, layers: List[SoilLayer], raise_context
+        self, layers: list[SoilLayer], raise_context
     ):
         with raise_context:
             profile = SoilProfile(name=_PROFILE_TEST_NAME, layers=layers)

--- a/tests/models/dsheetpiling/test_stages.py
+++ b/tests/models/dsheetpiling/test_stages.py
@@ -1,5 +1,3 @@
-from typing import Dict, Optional
-
 import pytest
 
 from geolib.models.dsheetpiling.dsheetpiling_model import DSheetPilingModel

--- a/tests/models/dsheetpiling/test_surfaces.py
+++ b/tests/models/dsheetpiling/test_surfaces.py
@@ -1,5 +1,5 @@
 from contextlib import nullcontext as does_not_raise
-from typing import Callable, List
+from typing import Callable
 
 import pytest
 from pydantic import ValidationError
@@ -79,7 +79,7 @@ class TestSurfaces:
         ],
     )
     def test_surface_initialization_with_different_points_arguments(
-        self, points: List[Point], run_expectation
+        self, points: list[Point], run_expectation
     ):
         surface_name = "Ground level -2m"
         with run_expectation:

--- a/tests/models/dstability/test_dstability_states.py
+++ b/tests/models/dstability/test_dstability_states.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import List
 
 import pytest
 

--- a/tests/models/dstability/test_loads.py
+++ b/tests/models/dstability/test_loads.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 from pydantic_core._pydantic_core import ValidationError
 
@@ -49,7 +47,7 @@ def _get_tree_load() -> TreeLoad:
 
 
 @pytest.fixture
-def _get_consolidations() -> List[Consolidation]:
+def _get_consolidations() -> list[Consolidation]:
     return [Consolidation(degree=100, layer_id=15)]
 
 
@@ -75,7 +73,7 @@ class TestConsolidation:
     def test_get_consolidations_fixture_is_valid(self, _get_consolidations):
         consolidations = _get_consolidations
 
-        assert isinstance(consolidations, List)
+        assert isinstance(consolidations, list)
         assert len(consolidations) > 0
         for consolidation in consolidations:
             assert isinstance(consolidation, Consolidation)

--- a/tests/models/dstability/test_results.py
+++ b/tests/models/dstability/test_results.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from geolib.models.dstability.dstability_model import DStabilityModel
@@ -45,7 +43,7 @@ def _persistable_circle() -> PersistableCircle:
     return PersistableCircle(Center=_left_center_persistable_point(), Radius=5)
 
 
-def _slip_plane() -> List[PersistablePoint]:
+def _slip_plane() -> list[PersistablePoint]:
     x_z_coordinates = [(0, 10), (2.5, 8), (5, 4), (2.5, 2), (10, 0)]
     return [PersistablePoint(X=x, Z=z) for x, z in x_z_coordinates]
 

--- a/tests/models/test_dseries_parser.py
+++ b/tests/models/test_dseries_parser.py
@@ -1,5 +1,4 @@
 from random import randint
-from typing import Dict, List, Tuple, Type
 
 import pytest
 from pydantic_core._pydantic_core import ValidationError
@@ -88,7 +87,7 @@ class TestParserUtil:
     )
     @pytest.mark.unittest
     def test_get_line_property_key_value_reversed_key_false(
-        self, text: str, expected_value: Tuple[str, str]
+        self, text: str, expected_value: tuple[str, str]
     ):
         assert get_line_property_key_value(text, reversed_key=False) == expected_value
 
@@ -108,18 +107,18 @@ class TestParserUtil:
     )
     @pytest.mark.unittest
     def test_get_line_property_key_value_reversed_key_true(
-        self, text: str, expected_value: Tuple[str, str]
+        self, text: str, expected_value: tuple[str, str]
     ):
         assert get_line_property_key_value(text, reversed_key=True) == expected_value
 
 
 class DummyTreeStructure(DSeriesTreeStructure):
     simple_property: int
-    list_property: List[int]
+    list_property: list[int]
 
 
 class DummyListTreeStructureCollection(DSeriesTreeStructureCollection):
-    tabbedtreestructures: List[DummyTreeStructure]
+    tabbedtreestructures: list[DummyTreeStructure]
 
 
 class TestDSeriesTreeStructure:
@@ -140,7 +139,7 @@ class TestDSeriesTreeStructure:
         assert str(e_info.value) == expected_error
 
     class DummyTreeStructureListFirst(DSeriesTreeStructure):
-        list_property: List[int]
+        list_property: list[int]
         single_property: int
 
     @pytest.mark.unittest
@@ -304,7 +303,7 @@ class TestDSeriesTreeStructure:
         class tp_test_composite_element(DSeriesTreeStructure):
             struct_name: str
             val_0: float
-            composite_val: List[tp_test_simple_element]
+            composite_val: list[tp_test_simple_element]
 
         # 1. Define test data.
         text_to_parse = (
@@ -398,7 +397,7 @@ class TestDSeriesTreeStructureCollection:
             val_2: float
 
         class tp_test_treecollection(DSeriesTreeStructureCollection):
-            tree_collection: List[tp_test_element]
+            tree_collection: list[tp_test_element]
 
         # 1. Define test data.
         text_to_parse = (
@@ -430,7 +429,7 @@ class TestDSeriesTreeStructureCollection:
             prop_2: float
 
         class tp_test_collection(DSeriesTreeStructureCollection):
-            tp_collection: List[tp_test_simplestruct]
+            tp_collection: list[tp_test_simplestruct]
 
         class tp_test_compositestruct(DSeriesTreeStructure):
             struct_name: str
@@ -439,7 +438,7 @@ class TestDSeriesTreeStructureCollection:
             extra_struct: tp_test_collection
 
         class tp_test_treecollection(DSeriesTreeStructureCollection):
-            tree_collection: List[tp_test_compositestruct]
+            tree_collection: list[tp_test_compositestruct]
 
         # 1. Define test data.
         text_to_parse = (
@@ -492,7 +491,7 @@ class DummyMatrixStructure(DSeriesTreeStructure):
 
 class TestDSeriesTreeStructureAsMatrix:
     class DummyMatrixTreeStructureCollection(DSeriesMatrixTreeStructureCollection):
-        dummymatrixtreestructure: List[DummyMatrixStructure]
+        dummymatrixtreestructure: list[DummyMatrixStructure]
 
     @pytest.mark.unittest
     def test_given_unequal_lines_when_parse_text_then_raise_exception(self):
@@ -576,7 +575,7 @@ class TestDSeriesTableStructure:
     def test_given_column_with_string_value_when_parse_then_returns_valid_structure(self):
         # 1. Define test data
         class test_table(DSeriesTableStructure):
-            test_table: List[Dict[str, str]]
+            test_table: list[dict[str, str]]
 
         string_value = "This is a string value"
         text_to_parse = f"""[COLUMN INDICATION]
@@ -599,7 +598,7 @@ class TestDSeriesWrappedTableStructure:
     def test_given_table_without_number_of_rows_structure_is_parsed(self):
         # 1. Prepare test data
         class test_structure(DSeriesWrappedTableStructure):
-            test_structure: List[Dict[str, float]]
+            test_structure: list[dict[str, float]]
 
         text_to_parse = """
             [TABLE]
@@ -656,7 +655,7 @@ class TestDSeriesInlineProperties:
         ],
     )
     def test_given_text_with_any_kind_of_properties_when_parse_text_then_returns_structure(
-        self, text_input: str, class_to_parse: Type
+        self, text_input: str, class_to_parse: type
     ):
         # 1. Run test.
         parsed_structure = class_to_parse.parse_text(text_input)
@@ -680,7 +679,7 @@ class TestDSeriesInlineProperties:
         ],
     )
     def test_given_text_with_header_when_parse_text_then_returns_structure(
-        self, text_input: str, class_to_parse: Type
+        self, text_input: str, class_to_parse: type
     ):
         # 1. Run test.
         class with_header(class_to_parse):
@@ -732,7 +731,7 @@ class TestDSeriesInlineProperties:
         ],
     )
     def test_given_text_without_key_when_get_property_key_value_then_returns_expected_property(
-        self, text_to_parse: str, expected_key: str, expected_result: Tuple[str, str]
+        self, text_to_parse: str, expected_key: str, expected_result: tuple[str, str]
     ):
         # 1. Define test data:
         expected_key = "dummy_key"
@@ -785,7 +784,7 @@ class TestDSeriesInlineMappedProperties:
         ],
     )
     def test_given_text_without_key_when_get_property_key_value_then_returns_expected_property(
-        self, text_to_parse: str, expected_key: str, expected_result: Tuple[str, str]
+        self, text_to_parse: str, expected_key: str, expected_result: tuple[str, str]
     ):
         # 1. Define test data:
         expected_key = "dummy_key"
@@ -835,7 +834,7 @@ class TestDSeriesUnmappedNameProperties:
         ],
     )
     def test_given_no_expected_property_when_get_property_key_value_then_returns_expected(
-        self, text_to_parse: str, expected_tuple: Tuple[str, str]
+        self, text_to_parse: str, expected_tuple: tuple[str, str]
     ):
         # 1. Prepare test data.
         key = "dummy_key"
@@ -855,7 +854,7 @@ class TestDSeriesUnmappedNameProperties:
 class TestDSeriesRepeatedGroupedProperties:
     class grouped_properties(DSeriesRepeatedGroupedProperties):
         property_one: int
-        property_list: List[str]
+        property_list: list[str]
         property_two: float
 
     @pytest.mark.integrationtest
@@ -921,7 +920,7 @@ class TestDSeriesRepeatedGroupsWithInlineMappedProperties:
         class mixed_group(DSeriesRepeatedGroupsWithInlineMappedProperties):
             property_one: int
             property_two: float
-            property_list: List[str]
+            property_list: list[str]
 
         text = (
             "property one = 42\n"
@@ -947,8 +946,8 @@ class TestDSeriesStructureCollection:
     ):
         # 1. Define test data.
         class multiple_properties(DSeriesStructureCollection):
-            property_one: List[DSeriesStructure]
-            property_two: List[DSeriesStructure]
+            property_one: list[DSeriesStructure]
+            property_two: list[DSeriesStructure]
 
         expected_error = (
             "This type of collection is only meant to have one field but 2 were defined."
@@ -968,7 +967,7 @@ class TestDSeriesStructureCollection:
         self,
     ):
         class default_collection(DSeriesStructureCollection):
-            collection_one: List[DSeriesStructure]
+            collection_one: list[DSeriesStructure]
 
         # 1. Define test data.
         text_to_parse = (
@@ -999,7 +998,7 @@ class TestDSeriesStructureCollection:
             property_dummy: int
 
         class default_collection(DSeriesStructureCollection):
-            data: List[inline_properties_structure]
+            data: list[inline_properties_structure]
 
         # 1. Define test data.
         text_to_parse = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import pytest
 
 from geolib.models import BaseDataClass
@@ -24,7 +22,7 @@ class TestGetFields:
         ],
     )
     def test_given_class_when_get_required_class_field_then_only_valid_fields_returned(
-        self, class_type: Type
+        self, class_type: type
     ):
         filtered_types = get_required_class_field(class_type)
         assert isinstance(filtered_types, list)
@@ -42,7 +40,7 @@ class TestGetFields:
         ],
     )
     def test_given_class_when_get_filtered_type_hints_then_only_valid_fields_returned(
-        self, class_type: Type
+        self, class_type: type
     ):
         filtered_types = get_filtered_type_hints(class_type)
         assert isinstance(filtered_types, list)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import sys
 from pathlib import Path
-from typing import List
 
 import pytest
 from teamcity import is_running_under_teamcity
@@ -34,7 +33,7 @@ class TestUtils:
         pipmain(["install", package])
 
     @staticmethod
-    def get_test_files_from_local_test_dir(dir_name: str, glob_filter: str) -> List[Path]:
+    def get_test_files_from_local_test_dir(dir_name: str, glob_filter: str) -> list[Path]:
         """Returns all the files that need to be used as test input parameters from a given directory.
 
         Args:
@@ -42,7 +41,7 @@ class TestUtils:
             glob_filter (str): Filter that will be applied with the glob function.
 
         Returns:
-            List[Path]: List of files matching the above criteria.
+            list[Path]: List of files matching the above criteria.
         """
         return [
             input_file


### PR DESCRIPTION
Since support for Python 3.9 was dropped, all supported versions of Python now have native basic type hinting available. All references to `typing`'s Dict, List, Optional, Set, Tuple, Type and Union have been replaced by the built-in Python equivalent.